### PR TITLE
Reorder model fields

### DIFF
--- a/src/django_upgrade/ast.py
+++ b/src/django_upgrade/ast.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import warnings
+from typing import Container
 from typing import Literal
 
 from tokenize_rt import Offset
@@ -49,4 +50,22 @@ def looks_like_test_client_call(
         and node.func.value.attr == client_name
         and isinstance(node.func.value.value, ast.Name)
         and node.func.value.value.id == "self"
+    )
+
+
+def is_name_attr(
+    node: ast.AST,
+    imports: dict[str, set[str]],
+    mods: tuple[str, ...],
+    names: Container[str],
+) -> bool:
+    return (
+        isinstance(node, ast.Name)
+        and node.id in names
+        and any(node.id in imports[mod] for mod in mods)
+    ) or (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id in mods
+        and node.attr in names
     )

--- a/src/django_upgrade/ast.py
+++ b/src/django_upgrade/ast.py
@@ -69,3 +69,13 @@ def is_name_attr(
         and node.value.id in mods
         and node.attr in names
     )
+
+
+def is_single_target_assign(node: ast.Assign | ast.AnnAssign) -> ast.AST | None:
+    if isinstance(node, ast.Assign) and len(node.targets) == 1:
+        return node.targets[0]
+
+    if isinstance(node, ast.AnnAssign) and node.value is not None:
+        return node.target
+
+    return None

--- a/src/django_upgrade/fixers/reorder_model_fields.py
+++ b/src/django_upgrade/fixers/reorder_model_fields.py
@@ -16,7 +16,6 @@ from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
 from django_upgrade.tokens import consume
 from django_upgrade.tokens import find_first_token_at_line
-from django_upgrade.tokens import find_last_token_at_line
 from django_upgrade.tokens import PHYSICAL_NEWLINE
 from django_upgrade.tokens import reverse_consume_non_semantic_elements
 
@@ -30,21 +29,38 @@ class ContentType(int, enum.Enum):
     """Enumeration of possible types of block in a django class"""
 
     UNKNOWN = 0
-    BARE_ANNOTATION = 1
-    FIELD_DECLARATION = 2
-    MANAGER_DECLARATION = 3
-    META_CLASS = 4
-    STR_METHOD = 5
-    CLEAN_METHOD = 6
-    SAVE_METHOD = 7
-    GET_ABSOLUTE_URL_METHOD = 8
-    CUSTOM_PROPERTY = 9
-    CUSTOM_METHOD = 10
-    CUSTOM_CLASS_METHOD = 11
-    CUSTOM_STATIC_METHOD = 12
+    FIELD_DECLARATION = enum.auto()
+    MANAGER_DECLARATION = enum.auto()
+    META_CLASS = enum.auto()
+    NATURAL_KEY_METHOD = enum.auto()
+    INIT_METHOD = enum.auto()
+    REPR_METHOD = enum.auto()
+    STR_METHOD = enum.auto()
+    CLEAN_METHOD = enum.auto()
+    SAVE_METHOD = enum.auto()
+    ASAVE_METHOD = enum.auto()
+    DELETE_METHOD = enum.auto()
+    ADELETE_METHOD = enum.auto()
+    GET_ABSOLUTE_URL_METHOD = enum.auto()
+    CUSTOM_PROPERTY = enum.auto()
+    CUSTOM_METHOD = enum.auto()
+    CUSTOM_CLASS_METHOD = enum.auto()
+    CUSTOM_STATIC_METHOD = enum.auto()
 
 
-decorator_to_content_type = {
+_function_name_to_content_type = {
+    "__str__": ContentType.STR_METHOD,
+    "__init__": ContentType.INIT_METHOD,
+    "__repr__": ContentType.REPR_METHOD,
+    "save": ContentType.SAVE_METHOD,
+    "get_absolute_url": ContentType.GET_ABSOLUTE_URL_METHOD,
+    "clean": ContentType.CLEAN_METHOD,
+    "delete": ContentType.DELETE_METHOD,
+    "asave": ContentType.ASAVE_METHOD,
+    "adelete": ContentType.ADELETE_METHOD,
+    "natural_key": ContentType.NATURAL_KEY_METHOD,
+}
+_decorator_to_content_type = {
     "property": ContentType.CUSTOM_PROPERTY,
     "cached_property": ContentType.CUSTOM_PROPERTY,
     "setter": ContentType.CUSTOM_PROPERTY,
@@ -53,54 +69,48 @@ decorator_to_content_type = {
     "staticmethod": ContentType.CUSTOM_STATIC_METHOD,
 }
 
+_PHYSICAL_NEWLINE_TOKEN = Token(name=PHYSICAL_NEWLINE, src="\n")
+
 
 def get_element_type_with_lineno(
     element: ast.AST,
 ) -> tuple[ContentType, int]:
-    if isinstance(element, ast.Assign):
-        if getattr(element.targets[0], "id", "") == "objects" or (
+    if (
+        isinstance(element, ast.Assign)
+        and len(element.targets) == 1
+        and isinstance((target := element.targets[0]), ast.Name)
+    ) or (
+        isinstance(element, ast.AnnAssign)
+        and isinstance((target := element.target), ast.Name)
+        and element.value is not None
+    ):
+        if target.id == "objects" or (
             isinstance(element.value, ast.Call)
-            and "Manager"
-            in getattr(element.value.func, "id", "")  # TODO: could be endswith check ?
+            and "Manager" in getattr(element.value.func, "id", "")
         ):
             # Because Manager definition order in the class matter, it is not a
             # safe idea to try distinguishing the `object` manager from other ones.
             # https://docs.djangoproject.com/fr/4.2/topics/db/managers/#default-managers
             return ContentType.MANAGER_DECLARATION, element.lineno
-
-        if isinstance(element.targets[0], ast.Name):
-            return ContentType.FIELD_DECLARATION, element.lineno
+        return ContentType.FIELD_DECLARATION, element.lineno
 
     if isinstance(element, ast.ClassDef) and element.name == "Meta":
         return ContentType.META_CLASS, element.lineno
 
     if isinstance(element, ast.FunctionDef):
         el_lineno = element.lineno - len(element.decorator_list)
-        if element.name == "__str__":
-            return ContentType.STR_METHOD, el_lineno
-        elif element.name == "save":
-            return ContentType.SAVE_METHOD, el_lineno
-        elif element.name == "get_absolute_url":
-            return ContentType.GET_ABSOLUTE_URL_METHOD, el_lineno
-        elif element.name == "clean":
-            return ContentType.CLEAN_METHOD, el_lineno
-        else:
-            if any(
-                (dec_name := getattr(decorator, "id", getattr(decorator, "attr", "")))
-                in decorator_to_content_type.keys()
-                for decorator in element.decorator_list
+        if content_type := _function_name_to_content_type.get(element.name):
+            return content_type, el_lineno
+
+        for decorator in element.decorator_list:
+            # We only need to check for `@foo` or `@foo.bar`.
+            if content_type := _decorator_to_content_type.get(
+                getattr(decorator, "id", getattr(decorator, "attr", ""))
             ):
-                return decorator_to_content_type[dec_name], el_lineno
+                return content_type, el_lineno
 
-            return ContentType.CUSTOM_METHOD, el_lineno
+        return ContentType.CUSTOM_METHOD, el_lineno
 
-    if isinstance(element, ast.AnnAssign):
-        if getattr(element.target, "id", "") == "objects":
-            return ContentType.MANAGER_DECLARATION, element.lineno
-        if isinstance(element.target, ast.Name):
-            return ContentType.FIELD_DECLARATION, element.lineno
-        if element.value is None:
-            return ContentType.BARE_ANNOTATION, element.lineno
     return ContentType.UNKNOWN, element.lineno
 
 
@@ -132,46 +142,50 @@ def visit_ClassDef(
             )
         )
     ):
-        element_types: list[ContentType] = []
         prev_element_type: ContentType | None = None
-        element_types_to_range: list[tuple[int, int, ContentType]] = []
-        start_lineno = node.lineno
+        prev_start_lineno = node.lineno
+        element_types_with_range: list[tuple[ContentType, int, int]] = []
         need_reordering = False
 
         for element in node.body:
-            element_type, element_start_lineno = get_element_type_with_lineno(element)
-            if element_type is ContentType.UNKNOWN:
+            curr_element_type, curr_element_start_lineno = get_element_type_with_lineno(
+                element
+            )
+            if curr_element_type is prev_element_type:
+                # Bind element of same type together.
                 continue
 
-            if prev_element_type == element_type:
+            if curr_element_type is ContentType.UNKNOWN:
+                # If we don't know the type of the element, bind it with preceding one
+                # since it's where he was before anyway.
                 continue
 
             if prev_element_type is not None:
-                element_types_to_range.append(
-                    (start_lineno, element_start_lineno - 1, prev_element_type)
+                element_types_with_range.append(
+                    (
+                        prev_element_type,
+                        prev_start_lineno,
+                        curr_element_start_lineno - 1,
+                    )
                 )
+                if curr_element_type < prev_element_type:
+                    need_reordering = True
 
-            start_lineno = element_start_lineno
-            prev_element_type = element_type
-
-            if any(element_type < prev_element for prev_element in element_types):
-                need_reordering = True
-            else:
-                element_types.append(element_type)
+            prev_start_lineno = curr_element_start_lineno
+            prev_element_type = curr_element_type
 
         if need_reordering:
-            # if False:
-            #     yield
-            element_types_to_range.append(  # Don't forget the last element
+            # Don't forget the last element
+            element_types_with_range.append(
                 (
-                    start_lineno,
-                    node.end_lineno,
                     prev_element_type,
-                )  # type: ignore[arg-type]  #ast.ClassDef always have end_lineno
+                    prev_start_lineno,
+                    node.end_lineno,
+                )  # type: ignore[arg-type]  # ast.ClassDef always have end_lineno
             )
             yield ast_start_offset(node), partial(
                 reorder_class_body,
-                element_types_to_range=element_types_to_range,
+                element_types_with_range=element_types_with_range,
             )
 
 
@@ -179,44 +193,39 @@ def reorder_class_body(
     tokens: list[Token],
     i: int,
     *,
-    element_types_to_range: list[tuple[int, int, ContentType]],
+    element_types_with_range: list[tuple[ContentType, int, int]],
 ) -> None:
-    element_types_to_tokens: defaultdict[ContentType, list[Token]] = defaultdict(list)
-
-    j = (
-        find_last_token_at_line(
-            tokens, i, line=next(iter(element_types_to_range))[0] - 1
-        )
-        + 1
+    j = find_first_token_at_line(
+        tokens,
+        i,
+        line=element_types_with_range[0][1],
     )
     j = reverse_consume_non_semantic_elements(tokens, j)
     new_tokens = tokens[i:j]
 
-    for start, end, el_type in element_types_to_range:
-        j = find_first_token_at_line(tokens, j, line=start)
+    element_types_to_tokens: defaultdict[ContentType, list[Token]] = defaultdict(list)
+    for el_type, start_lineno, end_lineno in element_types_with_range:
+        j = find_first_token_at_line(tokens, j, line=start_lineno)
         j = reverse_consume_non_semantic_elements(tokens, j)
         j = consume(tokens, j - 1, name=PHYSICAL_NEWLINE) + 1
 
-        last_token_idx = find_last_token_at_line(tokens, j, line=end) + 1
+        last_token_idx = find_first_token_at_line(tokens, j, line=end_lineno + 1)
         k = reverse_consume_non_semantic_elements(tokens, last_token_idx)
         if (
             element_types_to_tokens[el_type]
             and element_types_to_tokens[el_type][-1].name != PHYSICAL_NEWLINE
         ):
-            # Separate chunks of the same ContentType with newlines.
-            # It is usefull for most but not really for Field and Manager declarations.
-            # TODO: maybe special case here ?
-            element_types_to_tokens[el_type].append(
-                Token(name=PHYSICAL_NEWLINE, src="\n")
-            )
+            # When merging chunks of the same ContentType, separate them with newlines.
+            # This is necessary for methods definitions.
+            element_types_to_tokens[el_type].append(_PHYSICAL_NEWLINE_TOKEN)
         element_types_to_tokens[el_type].extend(tokens[j:k])
         j = last_token_idx
 
     # Replace class body with ordered tokens.
     nb_blocks = len(element_types_to_tokens)
     for idx, (_, el_type_tokens) in enumerate(sorted(element_types_to_tokens.items())):
-        if el_type_tokens[-1].name != PHYSICAL_NEWLINE and not idx == nb_blocks - 1:
+        if el_type_tokens[-1].name != PHYSICAL_NEWLINE and not idx + 1 == nb_blocks:
             # Ensure we have a trailing newline for every block (except the last one).
-            el_type_tokens.append(Token(name=PHYSICAL_NEWLINE, src="\n"))
+            el_type_tokens.append(_PHYSICAL_NEWLINE_TOKEN)
         new_tokens.extend(el_type_tokens)
     tokens[i:j] = new_tokens

--- a/src/django_upgrade/fixers/reorder_model_fields.py
+++ b/src/django_upgrade/fixers/reorder_model_fields.py
@@ -15,9 +15,9 @@ from django_upgrade.ast import is_single_target_assign
 from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import PHYSICAL_NEWLINE
 from django_upgrade.tokens import consume
 from django_upgrade.tokens import find_first_token_at_line
-from django_upgrade.tokens import PHYSICAL_NEWLINE
 from django_upgrade.tokens import reverse_consume_non_semantic_elements
 
 fixer = Fixer(
@@ -112,7 +112,11 @@ def get_element_type_with_lineno(
             # Because Manager definition order in the class matter, it is not a
             # safe idea to try distinguishing the `object` manager from other ones.
             # https://docs.djangoproject.com/fr/4.2/topics/db/managers/#default-managers
+            # So we juste flag them all here, that way the order will be preserved.
             return ContentType.MANAGER_DECLARATION, element.lineno
+        if content_type := _function_name_to_content_type.get(target.id):
+            # Handle case like `__repr__ = my_custom_repr()`
+            return content_type, element.lineno
         return ContentType.FIELD_DECLARATION, element.lineno
 
     if isinstance(element, ast.ClassDef) and element.name == "Meta":

--- a/src/django_upgrade/fixers/reorder_model_fields.py
+++ b/src/django_upgrade/fixers/reorder_model_fields.py
@@ -11,6 +11,7 @@ from tokenize_rt import Token
 
 from django_upgrade.ast import ast_start_offset
 from django_upgrade.ast import is_name_attr
+from django_upgrade.ast import is_single_target_assign
 from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
@@ -76,13 +77,9 @@ def get_element_type_with_lineno(
     element: ast.AST,
 ) -> tuple[ContentType, int]:
     if (
-        isinstance(element, ast.Assign)
-        and len(element.targets) == 1
-        and isinstance((target := element.targets[0]), ast.Name)
-    ) or (
-        isinstance(element, ast.AnnAssign)
-        and isinstance((target := element.target), ast.Name)
-        and element.value is not None
+        isinstance(element, (ast.Assign, ast.AnnAssign))
+        and (target := is_single_target_assign(element))
+        and isinstance(target, ast.Name)
     ):
         if target.id == "objects" or (
             isinstance(element.value, ast.Call)

--- a/src/django_upgrade/fixers/reorder_model_fields.py
+++ b/src/django_upgrade/fixers/reorder_model_fields.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import ast
+import enum
+from collections import defaultdict
+from functools import partial
+from typing import Iterable
+
+from tokenize_rt import Offset
+from tokenize_rt import Token
+
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.ast import is_name_attr
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import consume
+from django_upgrade.tokens import find_first_token_at_line
+from django_upgrade.tokens import find_last_token_at_line
+from django_upgrade.tokens import PHYSICAL_NEWLINE
+from django_upgrade.tokens import reverse_consume_non_semantic_elements
+
+fixer = Fixer(
+    __name__,
+    min_version=(0, 0),
+)
+
+
+class ContentType(int, enum.Enum):
+    """Enumeration of possible types of block in a django class"""
+
+    UNKNOWN = 0
+    BARE_ANNOTATION = 1
+    FIELD_DECLARATION = 2
+    MANAGER_DECLARATION = 3
+    META_CLASS = 4
+    STR_METHOD = 5
+    CLEAN_METHOD = 6
+    SAVE_METHOD = 7
+    GET_ABSOLUTE_URL_METHOD = 8
+    CUSTOM_PROPERTY = 9
+    CUSTOM_METHOD = 10
+    CUSTOM_CLASS_METHOD = 11
+    CUSTOM_STATIC_METHOD = 12
+
+
+decorator_to_content_type = {
+    "property": ContentType.CUSTOM_PROPERTY,
+    "cached_property": ContentType.CUSTOM_PROPERTY,
+    "classmethod": ContentType.CUSTOM_CLASS_METHOD,
+    "staticmethod": ContentType.CUSTOM_STATIC_METHOD,
+}
+
+
+def get_element_type_with_lineno(
+    element: ast.AST,
+) -> tuple[ContentType, int]:
+    if isinstance(element, ast.Assign):
+        if getattr(element.targets[0], "id", "") == "objects" or (
+            isinstance(element.value, ast.Call)
+            and "Manager"
+            in getattr(element.value.func, "id", "")  # TODO: could be endswith check ?
+        ):
+            # Because Manager definition order in the class matter, it is not a
+            # safe idea to try distinguishing the `object` manager from other ones.
+            # https://docs.djangoproject.com/fr/4.2/topics/db/managers/#default-managers
+            return ContentType.MANAGER_DECLARATION, element.lineno
+
+        if isinstance(element.targets[0], ast.Name):
+            return ContentType.FIELD_DECLARATION, element.lineno
+
+    if isinstance(element, ast.ClassDef) and element.name == "Meta":
+        return ContentType.META_CLASS, element.lineno
+
+    if isinstance(element, ast.FunctionDef):
+        el_lineno = element.lineno - len(element.decorator_list)
+        if element.name == "__str__":
+            return ContentType.STR_METHOD, el_lineno
+        elif element.name == "save":
+            return ContentType.SAVE_METHOD, el_lineno
+        elif element.name == "get_absolute_url":
+            return ContentType.GET_ABSOLUTE_URL_METHOD, el_lineno
+        elif element.name == "clean":
+            return ContentType.CLEAN_METHOD, el_lineno
+        else:
+            if any(
+                (dec_name := getattr(decorator, "id", ""))
+                in decorator_to_content_type.keys()
+                for decorator in element.decorator_list
+            ):
+                return decorator_to_content_type[dec_name], el_lineno
+
+            return ContentType.CUSTOM_METHOD, el_lineno
+
+    if isinstance(element, ast.AnnAssign):
+        if getattr(element.target, "id", "") == "objects":
+            return ContentType.MANAGER_DECLARATION, element.lineno
+        if isinstance(element.target, ast.Name):
+            return ContentType.FIELD_DECLARATION, element.lineno
+        if element.value is None:
+            return ContentType.BARE_ANNOTATION, element.lineno
+    return ContentType.UNKNOWN, element.lineno
+
+
+@fixer.register(ast.ClassDef)
+def visit_ClassDef(
+    state: State,
+    node: ast.ClassDef,
+    parents: list[ast.AST],
+) -> Iterable[tuple[Offset, TokenFunc]]:
+    if (
+        isinstance(parents[-1], ast.Module)
+        and state.looks_like_models_file
+        and any(
+            is_name_attr(
+                base_node,
+                state.from_imports,
+                ("models",),
+                ("Model",),
+            )
+            for base_node in node.bases
+        )
+    ):
+        element_types: list[ContentType] = []
+        prev_element_type: ContentType | None = None
+        element_types_to_range: list[tuple[int, int, ContentType]] = []
+        start_lineno = node.lineno
+        need_reordering = False
+
+        for element in node.body:
+            element_type, element_start_lineno = get_element_type_with_lineno(element)
+            if element_type is ContentType.UNKNOWN:
+                continue
+
+            if prev_element_type == element_type:
+                continue
+
+            if prev_element_type is not None:
+                element_types_to_range.append(
+                    (start_lineno, element_start_lineno - 1, prev_element_type)
+                )
+
+            start_lineno = element_start_lineno
+            prev_element_type = element_type
+
+            if any(element_type < prev_element for prev_element in element_types):
+                need_reordering = True
+            else:
+                element_types.append(element_type)
+
+        if need_reordering:
+            # if False:
+            #     yield
+            element_types_to_range.append(  # Don't forget the last element
+                (
+                    start_lineno,
+                    node.end_lineno,
+                    prev_element_type,
+                )  # type: ignore[arg-type]  #ast.ClassDef always have end_lineno
+            )
+            yield ast_start_offset(node), partial(
+                reorder_class_body,
+                element_types_to_range=element_types_to_range,
+            )
+
+
+def reorder_class_body(
+    tokens: list[Token],
+    i: int,
+    *,
+    element_types_to_range: list[tuple[int, int, ContentType]],
+) -> None:
+    element_types_to_tokens: defaultdict[ContentType, list[Token]] = defaultdict(list)
+
+    j = (
+        find_last_token_at_line(
+            tokens, i, line=next(iter(element_types_to_range))[0] - 1
+        )
+        + 1
+    )
+    j = reverse_consume_non_semantic_elements(tokens, j)
+    new_tokens = tokens[i:j]
+
+    for start, end, el_type in element_types_to_range:
+        j = find_first_token_at_line(tokens, j, line=start)
+        j = reverse_consume_non_semantic_elements(tokens, j)
+        j = consume(tokens, j - 1, name=PHYSICAL_NEWLINE) + 1
+
+        last_token_idx = find_last_token_at_line(tokens, j, line=end) + 1
+        k = reverse_consume_non_semantic_elements(tokens, last_token_idx)
+        if (
+            element_types_to_tokens[el_type]
+            and element_types_to_tokens[el_type][-1].name != PHYSICAL_NEWLINE
+        ):
+            # Separate chunks of the same ContentType with newlines.
+            # It is usefull for most but not really for Field and Manager declarations.
+            # TODO: maybe special case here ?
+            element_types_to_tokens[el_type].append(
+                Token(name=PHYSICAL_NEWLINE, src="\n")
+            )
+        element_types_to_tokens[el_type].extend(tokens[j:k])
+        j = last_token_idx
+
+    # Replace class body with ordered tokens.
+    nb_blocks = len(element_types_to_tokens)
+    for idx, (_, el_type_tokens) in enumerate(sorted(element_types_to_tokens.items())):
+        if el_type_tokens[-1].name != PHYSICAL_NEWLINE and not idx == nb_blocks - 1:
+            # Ensure we have a trailing newline for every block (except the last one).
+            el_type_tokens.append(Token(name=PHYSICAL_NEWLINE, src="\n"))
+        new_tokens.extend(el_type_tokens)
+    tokens[i:j] = new_tokens

--- a/src/django_upgrade/fixers/reorder_model_fields.py
+++ b/src/django_upgrade/fixers/reorder_model_fields.py
@@ -47,6 +47,8 @@ class ContentType(int, enum.Enum):
 decorator_to_content_type = {
     "property": ContentType.CUSTOM_PROPERTY,
     "cached_property": ContentType.CUSTOM_PROPERTY,
+    "setter": ContentType.CUSTOM_PROPERTY,
+    "deleter": ContentType.CUSTOM_PROPERTY,
     "classmethod": ContentType.CUSTOM_CLASS_METHOD,
     "staticmethod": ContentType.CUSTOM_STATIC_METHOD,
 }
@@ -84,7 +86,7 @@ def get_element_type_with_lineno(
             return ContentType.CLEAN_METHOD, el_lineno
         else:
             if any(
-                (dec_name := getattr(decorator, "id", ""))
+                (dec_name := getattr(decorator, "id", getattr(decorator, "attr", "")))
                 in decorator_to_content_type.keys()
                 for decorator in element.decorator_list
             ):

--- a/src/django_upgrade/tokens.py
+++ b/src/django_upgrade/tokens.py
@@ -21,6 +21,9 @@ PHYSICAL_NEWLINE = "NL"
 STRING = "STRING"
 
 
+BRACES = {"(": ")", "[": "]", "{": "}"}
+OPENING, CLOSING = frozenset(BRACES), frozenset(BRACES.values())
+
 # Basic functions
 
 
@@ -68,30 +71,61 @@ def find_first_token(tokens: list[Token], i: int, *, node: ast.AST) -> int:
     """
     Find the first token corresponding to the given ast node.
     """
-    j = i
-    while tokens[j].line is None or tokens[j].line < node.lineno:
-        j += 1
+    while tokens[i].line is None or tokens[i].line < node.lineno:
+        i += 1
     while (
-        tokens[j].utf8_byte_offset is None
-        or tokens[j].utf8_byte_offset < node.col_offset
+        tokens[i].utf8_byte_offset is None
+        or tokens[i].utf8_byte_offset < node.col_offset
     ):
-        j += 1
-    return j
+        i += 1
+    return i
 
 
 def find_last_token(tokens: list[Token], i: int, *, node: ast.AST) -> int:
     """
     Find the last token corresponding to the given ast node.
     """
-    j = i
-    while tokens[j].line is None or tokens[j].line < node.end_lineno:
-        j += 1
+    while tokens[i].line is None or tokens[i].line < node.end_lineno:
+        i += 1
     while (
-        tokens[j].utf8_byte_offset is None
-        or tokens[j].utf8_byte_offset < node.end_col_offset
+        tokens[i].utf8_byte_offset is None
+        or tokens[i].utf8_byte_offset < node.end_col_offset
     ):
-        j += 1
-    return j - 1
+        i += 1
+    return i - 1
+
+
+def reverse_consume_non_semantic_elements(tokens: list[Token], i: int) -> int:
+    """
+    Rewind past any non-semantic tokens to bind preceding
+    non-semantic tokens (PHYSICAL_NEWLINE, COMMENTS, ..) with a chunk of lines.
+    """
+    while tokens[i - 1].name in NON_CODING_TOKENS:
+        i -= 1
+    return i
+
+
+def find_first_token_at_line(
+    tokens: list[Token],
+    i: int,
+    *,
+    line: int,
+) -> int:
+    """
+    Find the first token corresponding to the given line number.
+    """
+    while tokens[i].line is None or tokens[i].line < line:
+        i += 1
+    return i
+
+
+def find_last_token_at_line(tokens: list[Token], i: int, *, line: int) -> int:
+    """
+    Find the last token corresponding to the given line number.
+    """
+    while tokens[i].line is None or tokens[i].line <= line:
+        i += 1
+    return i - 1
 
 
 def extract_indent(tokens: list[Token], i: int) -> tuple[int, str]:
@@ -121,11 +155,6 @@ def alone_on_line(tokens: list[Token], start_idx: int, end_idx: int) -> bool:
 
 
 # More complex mini-parsers
-
-
-BRACES = {"(": ")", "[": "]", "{": "}"}
-
-
 def parse_call_args(
     tokens: list[Token],
     i: int,
@@ -157,10 +186,6 @@ def parse_call_args(
         i += 1
 
     return args, i
-
-
-BRACES = {"(": ")", "[": "]", "{": "}"}
-OPENING, CLOSING = frozenset(BRACES), frozenset(BRACES.values())
 
 
 def find_block_start(tokens: list[Token], i: int) -> int:

--- a/src/django_upgrade/tokens.py
+++ b/src/django_upgrade/tokens.py
@@ -96,10 +96,7 @@ def find_last_token(tokens: list[Token], i: int, *, node: ast.AST) -> int:
 
 
 def reverse_consume_non_semantic_elements(tokens: list[Token], i: int) -> int:
-    """
-    Rewind past any non-semantic tokens to bind preceding
-    non-semantic tokens (PHYSICAL_NEWLINE, COMMENTS, ..) with a chunk of lines.
-    """
+    """Rewind past any non-semantic tokens (PHYSICAL_NEWLINE, COMMENTS, ...)"""
     while tokens[i - 1].name in NON_CODING_TOKENS:
         i -= 1
     return i
@@ -117,15 +114,6 @@ def find_first_token_at_line(
     while tokens[i].line is None or tokens[i].line < line:
         i += 1
     return i
-
-
-def find_last_token_at_line(tokens: list[Token], i: int, *, line: int) -> int:
-    """
-    Find the last token corresponding to the given line number.
-    """
-    while tokens[i].line is None or tokens[i].line <= line:
-        i += 1
-    return i - 1
 
 
 def extract_indent(tokens: list[Token], i: int) -> tuple[int, str]:

--- a/tests/fixers/test_reorder_model_fields.py
+++ b/tests/fixers/test_reorder_model_fields.py
@@ -533,6 +533,7 @@ def test_bare_annotations_untouched():
 
         class Article(models.Model):
             a: int
+
             author_name = models.CharField(max_length=100, verbose_name=_("Nom"))
 
             objects: int = models.Manager()
@@ -563,6 +564,35 @@ def test_weird_repr():
             objects = models.Manager()
 
             __repr__ = my_custom_repr()
+        """,
+        settings,
+        filename="blog/models/article.py",
+    )
+
+
+def test_preserve_leading_empty_lines():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class MyModel(models.Model):
+            '''docstring'''
+
+            class Meta:
+                abstract = True
+
+            title = models.CharField(max_length=255, verbose_name="H1")
+        """,
+        """\
+        from django.db import models
+
+        class MyModel(models.Model):
+            '''docstring'''
+
+            title = models.CharField(max_length=255, verbose_name="H1")
+
+            class Meta:
+                abstract = True
         """,
         settings,
         filename="blog/models/article.py",

--- a/tests/fixers/test_reorder_model_fields.py
+++ b/tests/fixers/test_reorder_model_fields.py
@@ -1,0 +1,677 @@
+from __future__ import annotations
+
+import pytest
+
+from django_upgrade.data import Settings
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
+
+settings = Settings(target_version=(4, 2))
+
+
+def test_noop_wrong_filemname():
+    check_noop(
+        """\
+        from django.db import models
+
+        class Article(models.Model):
+            objects = models.Manager()
+            author_name = models.CharField(max_length=100, verbose_name=_("Nom"))
+        """,
+        settings,
+    )
+
+
+def test_noop_ordered_class():
+    check_noop(
+        """\
+        from django.db import models
+
+        class Article(models.Model):
+            author_name = models.CharField(max_length=100, verbose_name=_("Nom"))
+
+            objects = models.Manager()
+            validated = ValidatedCommentManager()
+
+            class Meta:
+                verbose_name = _("Commentaire Blog")
+                verbose_name_plural = _("Commentaires Blog")
+
+            def __str__(self):
+                return f"Comment - {self.author_name}..."
+
+            def clean(self):
+                pass
+
+            def save(self, *args, **kwargs):
+                super().save(*args, **kwargs)
+
+            def get_absolute_url(self) -> str:
+                return ""
+
+            @property
+            def edit_link(self):
+                return urljoin(
+                    settings.MY_DOMAIN,
+                    reverse(
+                        "admin:blog_comment_change",
+                        args=(self.id,),
+                    ),
+                )
+
+            @cached_property
+            def raw_content(self):
+                return html.unescape(strip_tags(self.content))
+
+            def my_method(self) -> str:
+                return ""
+
+            @classmethod
+            def my_class_method(cls) -> str:
+                return ""
+
+            @staticmethod
+            def my_static_method() -> str:
+                return ""
+        """,
+        settings,
+        filename="blog/models/article.py",
+    )
+
+
+def test_last_element_expr():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Article(models.Model):
+            title = models.CharField(max_length=255, verbose_name="H1")
+
+            def my_method(self) -> str:
+                return ""
+
+            my_method.short_description = "short desc"
+
+            sub_title = models.CharField(max_length=255, verbose_name="H1")
+
+            def my_method2(self) -> str:
+                return ""
+
+            my_method2.short_description = "short desc2"
+        """,
+        """\
+        from django.db import models
+
+        class Article(models.Model):
+            title = models.CharField(max_length=255, verbose_name="H1")
+
+            sub_title = models.CharField(max_length=255, verbose_name="H1")
+
+            def my_method(self) -> str:
+                return ""
+
+            my_method.short_description = "short desc"
+
+            def my_method2(self) -> str:
+                return ""
+
+            my_method2.short_description = "short desc2"
+            """,
+        settings,
+        filename="blog/models/article.py",
+    )
+
+
+def test_properties():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Article(models.Model):
+            title = models.CharField(max_length=255, verbose_name="H1")
+
+            @property
+            def my_property(self) -> str:
+                return ""
+
+            sub_title = models.CharField(max_length=255, verbose_name="H1")
+
+            @cached_property
+            def my_cached_property(self) -> str:
+                return ""
+        """,
+        """\
+        from django.db import models
+
+        class Article(models.Model):
+            title = models.CharField(max_length=255, verbose_name="H1")
+
+            sub_title = models.CharField(max_length=255, verbose_name="H1")
+
+            @property
+            def my_property(self) -> str:
+                return ""
+
+            @cached_property
+            def my_cached_property(self) -> str:
+                return ""
+            """,
+        settings,
+        filename="blog/models/article.py",
+    )
+
+
+def test_extra_manager():
+    check_transformed(
+        """\
+        from django.db import models
+        from foo import MyCustomManager
+
+        class Article(models.Model):
+            '''My Article class'''
+            objects = MyCustomManager()
+            title = models.CharField(max_length=255, verbose_name="H1")
+
+            @property
+            def my_property(self) -> str:
+                return ""
+
+            manager_2 = MyCustomManager()
+        """,
+        """\
+        from django.db import models
+        from foo import MyCustomManager
+
+        class Article(models.Model):
+            '''My Article class'''
+            title = models.CharField(max_length=255, verbose_name="H1")
+
+            objects = MyCustomManager()
+
+            manager_2 = MyCustomManager()
+
+            @property
+            def my_property(self) -> str:
+                return ""
+        """,
+        settings,
+        filename="blog/models/article.py",
+    )
+
+
+def test_preceding_comments():
+    check_transformed(
+        """\
+        from django.db import models
+        from foo import MyCustomManager
+
+        class Article(models.Model):
+            # This comment describe
+            # The following custom manager
+            objects = MyCustomManager()
+
+            # This is a comment
+
+            # This one too
+            title = models.CharField(max_length=255, verbose_name="H1")
+
+            @property
+            def my_property(self) -> str:
+                '''Super useful property'''
+                return ""
+
+            manager_2 = MyCustomManager()
+
+            def test(self):
+                return None
+
+            # Some random commented code
+            # # AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+            # BBB = models.BooleanField(default=True)
+            # DDD = models.BooleanField(default=True)
+
+            # CCC = models.BooleanField(
+            #     default=True
+            # )  # CCC
+
+            def save(self, *args, **kwargs):
+                super().save(*args, **kwargs)
+        """,
+        """\
+        from django.db import models
+        from foo import MyCustomManager
+
+        class Article(models.Model):
+            # This is a comment
+
+            # This one too
+            title = models.CharField(max_length=255, verbose_name="H1")
+
+            # This comment describe
+            # The following custom manager
+            objects = MyCustomManager()
+
+            manager_2 = MyCustomManager()
+
+            # Some random commented code
+            # # AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+            # BBB = models.BooleanField(default=True)
+            # DDD = models.BooleanField(default=True)
+
+            # CCC = models.BooleanField(
+            #     default=True
+            # )  # CCC
+
+            def save(self, *args, **kwargs):
+                super().save(*args, **kwargs)
+
+            @property
+            def my_property(self) -> str:
+                '''Super useful property'''
+                return ""
+
+            def test(self):
+                return None
+        """,
+        settings,
+        filename="blog/models/article.py",
+    )
+
+
+def test_trailing_line_comments():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Article(models.Model):
+            mail_range: str  # bla bla bla bla
+            nb_reviews = models.IntegerField(default=0)  # AAA
+
+            def my_method(self) -> str:
+                return ""
+
+            def __str__(self):
+                return "FOO"
+
+        """,
+        """\
+        from django.db import models
+
+        class Article(models.Model):
+            mail_range: str  # bla bla bla bla
+            nb_reviews = models.IntegerField(default=0)  # AAA
+
+            def __str__(self):
+                return "FOO"
+
+            def my_method(self) -> str:
+                return ""
+
+        """,
+        settings,
+        filename="blog/models/article.py",
+    )
+
+
+def test_clash_with_other_fixers():
+    check_transformed(
+        """\
+        from django.db import models
+        from django.db.models import NullBooleanField
+
+        class Article(models.Model):
+            mail_range: str  # bla bla bla bla
+            author = models.OneToOneField("auth.User")  # AAA
+            valuable = NullBooleanField("Valuable")
+
+            def my_method(self) -> str:
+                return ""
+
+            def __str__(self):
+                return "FOO"
+
+            reviewer = models.OneToOneField("auth.User")  # B
+        """,
+        """\
+        from django.db import models
+        from django.db.models import BooleanField
+
+        class Article(models.Model):
+            mail_range: str  # bla bla bla bla
+            author = models.OneToOneField("auth.User", on_delete=models.CASCADE)  # AAA
+            valuable = BooleanField("Valuable", null=True)
+
+            reviewer = models.OneToOneField("auth.User", on_delete=models.CASCADE)  # B
+
+            def __str__(self):
+                return "FOO"
+
+            def my_method(self) -> str:
+                return ""
+        """,
+        settings,
+        filename="blog/models/article.py",
+    )
+
+
+def test_no_trailing_newline_class_end():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Article(models.Model):
+            author_name = models.CharField(max_length=100, verbose_name=_("Nom"))
+
+            objects = models.Manager()
+            validated = ValidatedCommentManager()
+
+            def __str__(self):
+                return f"Comment - {self.author_name}..."
+
+            class Meta:
+                verbose_name = _("Commentaire Blog")
+                verbose_name_plural = _("Commentaires Blog")
+
+            @property
+            def raw_content(self):
+                return html.unescape(strip_tags(self.content))
+
+        """,
+        """\
+        from django.db import models
+
+        class Article(models.Model):
+            author_name = models.CharField(max_length=100, verbose_name=_("Nom"))
+
+            objects = models.Manager()
+            validated = ValidatedCommentManager()
+
+            class Meta:
+                verbose_name = _("Commentaire Blog")
+                verbose_name_plural = _("Commentaires Blog")
+
+            def __str__(self):
+                return f"Comment - {self.author_name}..."
+
+            @property
+            def raw_content(self):
+                return html.unescape(strip_tags(self.content))
+
+        """,
+        settings,
+        filename="blog/models/article.py",
+    )
+
+
+def test_trailing_newlines():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Article(models.Model):
+            nb_reviews = models.IntegerField(default=0)  # AAA
+
+            def my_method(self) -> str:
+                return ""
+
+            def __str__(self):
+                return "FOO"
+        # Exactly 3 NL
+
+
+
+        class Foo:
+            pass
+        """,
+        """\
+        from django.db import models
+
+        class Article(models.Model):
+            nb_reviews = models.IntegerField(default=0)  # AAA
+
+            def __str__(self):
+                return "FOO"
+
+            def my_method(self) -> str:
+                return ""
+        # Exactly 3 NL
+
+
+
+        class Foo:
+            pass
+        """,
+        settings,
+        filename="blog/models/article.py",
+    )
+
+
+@pytest.mark.skip("Docstring as a comment is not supported.")
+def test_docstring_as_comment_fail():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class MyModel(models.Model):
+            class Meta:
+                abstract = True
+
+            '''Specific fields'''
+            title = models.CharField(max_length=255, verbose_name="H1")
+        """,
+        """\
+        from django.db import models
+
+        class MyModel(models.Model):
+            '''French fields'''
+            title = models.CharField(max_length=255, verbose_name="H1")
+
+            class Meta:
+                abstract = True
+        """,
+        settings,
+        filename="blog/models/article.py",
+    )
+
+
+def test_full_transform():
+    check_transformed(
+        """\
+        from __future__ import annotations
+
+        import datetime as dt
+        from urllib.parse import urljoin
+
+        import requests
+        from django.conf import settings
+        from django.db import models
+        from django.db.models import Prefetch
+        from django.db.models.signals import post_save
+        from django.dispatch import receiver
+        from django.urls import reverse
+        from django.utils import timezone
+        from django.utils.html import strip_tags
+        from django.utils.text import Truncator, slugify
+        from django.utils.translation import gettext_lazy as _
+
+
+        class EntryStatus(models.TextChoices):
+            PUBLISHED = "published"
+            SCHEDULED = "scheduled"
+            HIDDEN = "hidden"
+            SCRATCH = "scratch"
+
+
+        class ArticleQuerySet(models.QuerySet):
+            def with_validated_comments(self):
+                return self.prefetch_related(
+                    Prefetch(
+                        "comments",
+                        queryset=Comment.validated.all(),
+                    ),
+                )
+
+
+        ArticleManager = models.Manager.from_queryset(ArticleQuerySet)
+
+
+        class Article(PlusPlusMixin, models.Model, metaclass=PlusPlusMetaClass):
+            '''docstring'''
+            a: int
+            title = models.CharField(max_length=255, verbose_name="H1")
+            meta_title = models.CharField(
+                max_length=255,
+                blank=True,
+                verbose_name=_("Title"),
+                help_text=_("Utilisé pour les balises meta"),
+            )
+            # COMMENT
+            status = models.CharField(
+                choices=EntryStatus.choices,
+                max_length=50,
+                default="hidden",
+                verbose_name=_("Statut"),
+                db_index=True,
+            )
+
+            objects = ArticleManager()
+
+            lead = HTMLField(verbose_name=_("Texte d'intro de l'article"))
+            content = PlusPlusField(verbose_name=_("Contenu de l'article"))
+            excerpt = models.TextField(
+                blank=True,
+                verbose_name=_("Extrait"),
+            )
+
+            @property
+            def is_active(self) -> bool:
+                return True
+
+            def save(self, *args, **kwargs):
+                super().save(*args, **kwargs)
+
+            def count_words(self) -> int:
+                return strip_tags(self.content).count(" ") + 1
+
+            def method_none(self) -> None:
+                return None
+
+            def get_absolute_url(self) -> str:
+                return reverse(
+                    "blog:blog_multiple_views",
+                    kwargs={"slug": self.slug},
+                )
+
+            def __str__(self):
+                return f"Article: {self.title}"
+
+            class Meta:
+                ordering = ["-published_at"]
+                indexes = [
+                    models.Index(fields=["slug"], name="slug_index"),
+                    models.Index(fields=["title"], name="title_index"),
+                ]
+                verbose_name = _("Article")
+                verbose_name_plural = _("Articles")
+        """,
+        """\
+        from __future__ import annotations
+
+        import datetime as dt
+        from urllib.parse import urljoin
+
+        import requests
+        from django.conf import settings
+        from django.db import models
+        from django.db.models import Prefetch
+        from django.db.models.signals import post_save
+        from django.dispatch import receiver
+        from django.urls import reverse
+        from django.utils import timezone
+        from django.utils.html import strip_tags
+        from django.utils.text import Truncator, slugify
+        from django.utils.translation import gettext_lazy as _
+
+
+        class EntryStatus(models.TextChoices):
+            PUBLISHED = "published"
+            SCHEDULED = "scheduled"
+            HIDDEN = "hidden"
+            SCRATCH = "scratch"
+
+
+        class ArticleQuerySet(models.QuerySet):
+            def with_validated_comments(self):
+                return self.prefetch_related(
+                    Prefetch(
+                        "comments",
+                        queryset=Comment.validated.all(),
+                    ),
+                )
+
+
+        ArticleManager = models.Manager.from_queryset(ArticleQuerySet)
+
+
+        class Article(PlusPlusMixin, models.Model, metaclass=PlusPlusMetaClass):
+            '''docstring'''
+            a: int
+            title = models.CharField(max_length=255, verbose_name="H1")
+            meta_title = models.CharField(
+                max_length=255,
+                blank=True,
+                verbose_name=_("Title"),
+                help_text=_("Utilisé pour les balises meta"),
+            )
+            # COMMENT
+            status = models.CharField(
+                choices=EntryStatus.choices,
+                max_length=50,
+                default="hidden",
+                verbose_name=_("Statut"),
+                db_index=True,
+            )
+
+            lead = HTMLField(verbose_name=_("Texte d'intro de l'article"))
+            content = PlusPlusField(verbose_name=_("Contenu de l'article"))
+            excerpt = models.TextField(
+                blank=True,
+                verbose_name=_("Extrait"),
+            )
+
+            objects = ArticleManager()
+
+            class Meta:
+                ordering = ["-published_at"]
+                indexes = [
+                    models.Index(fields=["slug"], name="slug_index"),
+                    models.Index(fields=["title"], name="title_index"),
+                ]
+                verbose_name = _("Article")
+                verbose_name_plural = _("Articles")
+
+            def __str__(self):
+                return f"Article: {self.title}"
+
+            def save(self, *args, **kwargs):
+                super().save(*args, **kwargs)
+
+            def get_absolute_url(self) -> str:
+                return reverse(
+                    "blog:blog_multiple_views",
+                    kwargs={"slug": self.slug},
+                )
+
+            @property
+            def is_active(self) -> bool:
+                return True
+
+            def count_words(self) -> int:
+                return strip_tags(self.content).count(" ") + 1
+
+            def method_none(self) -> None:
+                return None
+        """,
+        settings,
+        filename="blog/models/article.py",
+    )

--- a/tests/fixers/test_reorder_model_fields.py
+++ b/tests/fixers/test_reorder_model_fields.py
@@ -99,8 +99,15 @@ def test_annotated_fields_and_managers():
 
         class Article(models.Model):
             author_name = models.CharField(max_length=100, verbose_name=_("Nom"))
-            objects: int = models.Manager()
-            truc = CustomManager()
+
+            people = models.Manager()
+            people2 = PersonQuerySet.as_manager()
+            people3 = foo.PersonQuerySet.as_manager()
+            other_module_manager = foo.MyManager()
+            from_q_manager = CustomManager.from_queryset(CustomQuerySet)()
+            objects: PollManager = PollManager()
+            dahl_objects = DahlBookManager()
+
             author_name2: str = models.CharField(max_length=100, verbose_name=_("Nom"))
         """,
         """\
@@ -111,8 +118,13 @@ def test_annotated_fields_and_managers():
 
             author_name2: str = models.CharField(max_length=100, verbose_name=_("Nom"))
 
-            objects: int = models.Manager()
-            truc = CustomManager()
+            people = models.Manager()
+            people2 = PersonQuerySet.as_manager()
+            people3 = foo.PersonQuerySet.as_manager()
+            other_module_manager = foo.MyManager()
+            from_q_manager = CustomManager.from_queryset(CustomQuerySet)()
+            objects: PollManager = PollManager()
+            dahl_objects = DahlBookManager()
         """,
         settings,
         filename="blog/models/article.py",

--- a/tests/fixers/test_reorder_model_fields.py
+++ b/tests/fixers/test_reorder_model_fields.py
@@ -544,6 +544,31 @@ def test_bare_annotations_untouched():
     )
 
 
+def test_weird_repr():
+    check_transformed(
+        """\
+        from django.db import models
+
+        class Article(models.Model):
+            objects = models.Manager()
+            __repr__ = my_custom_repr()
+            author_name = models.CharField(max_length=100, verbose_name=_("Nom"))
+        """,
+        """\
+        from django.db import models
+
+        class Article(models.Model):
+            author_name = models.CharField(max_length=100, verbose_name=_("Nom"))
+
+            objects = models.Manager()
+
+            __repr__ = my_custom_repr()
+        """,
+        settings,
+        filename="blog/models/article.py",
+    )
+
+
 def test_docstring_as_comment_not_supported():
     check_transformed(
         """\


### PR DESCRIPTION
## What it does

Reorder fields in a Django model to follow the [Django Style Guide](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/#model-style). 
This mostly implement autofix capability for the existing [flake8 linting rule](https://github.com/rocioar/flake8-django/wiki/%5BDJ12%5D-Order-of-Model's-inner-classes,-methods,-and-fields-does-not-follow-the-Django-Style-Guide)

## Why is this bad?
In large codebase, some Django models tend to become very big. 
Discovering the `Meta` attribute or finding some django specific methods (`save`, `get_absolute_url`, ...) can become time consuming when there is no convention enforced. 
Some method also usually work together (`clean` & `save` for ex) and it make more sense to keep them close. 
Manager order also matters and having them all around the place can lead to weird bugs when they are moved around

## How does it work

For every python class identified as being a Django model, do the following: 

- identify the type of every element in the class (field definition, manager, methods, ...) and build chunk of element of the same type. Un-categorized element will be bind to the previous chunk (that way they mostly stay in the place they were before).
- Reorder the chunks and replace the class body with it.

