### PR TITLE
Prefer `pytest.params(.., id=...)` over `pytest.mark.parametrize(..., ids=...)`

### DIFF
--- a/src/django_upgrade/fixers/parametrize_param.py
+++ b/src/django_upgrade/fixers/parametrize_param.py
@@ -1,6 +1,5 @@
 """
-Add the 'length' argument to get_random_string():
-https://docs.djangoproject.com/en/3.1/releases/3.1/#features-deprecated-in-3-1
+Use multiple `pytest.param(..., id=...)` over `ids=[...]`
 """
 from __future__ import annotations
 

--- a/src/django_upgrade/fixers/parametrize_param.py
+++ b/src/django_upgrade/fixers/parametrize_param.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import ast
 from functools import partial
+from typing import cast
 from typing import Iterable
 
 from tokenize_rt import Offset
@@ -19,9 +20,11 @@ from django_upgrade.tokens import delete_argument
 from django_upgrade.tokens import find
 from django_upgrade.tokens import find_first_token
 from django_upgrade.tokens import find_last_token
+from django_upgrade.tokens import insert
 from django_upgrade.tokens import OP
 from django_upgrade.tokens import parse_call_args
 from django_upgrade.tokens import replace
+from django_upgrade.tokens import reverse_consume_non_semantic_elements
 
 
 fixer = Fixer(
@@ -45,17 +48,18 @@ def visit_Call(
         and node.func.value.value.id == "pytest"
         and any((ids_node := kw).arg == "ids" for kw in node.keywords)
         and isinstance(ids_node.value, (ast.List, ast.Tuple))
-        and all(isinstance(id_const, ast.Constant) for id_const in ids_node.value.elts)
+        and ids_node.value.elts
+        and all(isinstance(el, ast.Constant) for el in ids_node.value.elts)
         and isinstance(node.args[1], (ast.List, ast.Tuple))
         and isinstance(node.args[1].elts[0], (ast.List, ast.Tuple))
+        and isinstance(node.args[0], (ast.Constant, ast.List, ast.Tuple))
     ):
         yield ast_start_offset(node), partial(
             update_parametrize_call,
-            node=node,
+            pytest_argnames=node.args[0],
+            pytest_argvalues=node.args[1],
             ids_node_idx=len(node.args) + node.keywords.index(ids_node),
-            ids_values=[
-                id_const.value for id_const in ids_node.value.elts  # type: ignore
-            ],
+            ids_values=[cast(ast.Constant, el).value for el in ids_node.value.elts],
         )
 
 
@@ -63,7 +67,8 @@ def update_parametrize_call(
     tokens: list[Token],
     i: int,
     *,
-    node: ast.Call,
+    pytest_argnames: ast.Constant | ast.List | ast.Tuple,
+    pytest_argvalues: ast.List | ast.Tuple,
     ids_node_idx: int,
     ids_values: list[str],
 ) -> None:
@@ -72,12 +77,21 @@ def update_parametrize_call(
     func_args, _ = parse_call_args(tokens, j)
     delete_argument(ids_node_idx, tokens, func_args)
 
+    nb_argnames = len(
+        pytest_argnames.value.split(",")
+        if isinstance(pytest_argnames, ast.Constant)
+        else pytest_argnames.elts
+    )
     # Update params
-    for param, id_value in zip(node.args[1].elts, ids_values):  # type: ignore
+    for param, id_value in zip(pytest_argvalues.elts, ids_values):
         start_idx = find_first_token(tokens, i, node=param)
         end_idx = find_last_token(tokens, j, node=param)
+        last_nl_idx = reverse_consume_non_semantic_elements(tokens, end_idx)
+        sep = "" if tokens[last_nl_idx - 1].matches(name=OP, src=",") else ", "
 
-        is_multiline = param.lineno != param.end_lineno
-        new_src = "" if (is_multiline or not param.elts) else ", "
-        replace(tokens, start_idx, src="pytest.param(")
-        replace(tokens, end_idx, src=f'{new_src}id="{id_value}")')
+        if nb_argnames == 1:
+            insert(tokens, start_idx, new_src="pytest.param(")
+            insert(tokens, end_idx + 2, new_src=f', id="{id_value}")')
+        else:
+            replace(tokens, start_idx, src="pytest.param(")
+            replace(tokens, end_idx, src=f'{sep}id="{id_value}")')

--- a/src/django_upgrade/fixers/parametrize_param.py
+++ b/src/django_upgrade/fixers/parametrize_param.py
@@ -1,0 +1,69 @@
+"""
+Add the 'length' argument to get_random_string():
+https://docs.djangoproject.com/en/3.1/releases/3.1/#features-deprecated-in-3-1
+"""
+from __future__ import annotations
+
+import ast
+import subprocess
+from functools import partial
+from pprint import pprint
+from typing import Iterable
+from typing import MutableMapping
+from weakref import WeakKeyDictionary
+
+import astpretty
+from tokenize_rt import Offset
+from tokenize_rt import Token
+
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.ast import is_rewritable_import_from
+from django_upgrade.compat import str_removesuffix
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import CODE
+from django_upgrade.tokens import find
+from django_upgrade.tokens import OP
+from django_upgrade.tokens import replace
+from django_upgrade.tokens import update_import_names
+
+fixer = Fixer(
+    __name__,
+    min_version=(0, 0),
+)
+
+
+def is_mongo_stage_node(node: ast.AST, stage_name: str) -> bool:
+    return (
+        isinstance(node, ast.Dict)
+        and len(node.keys) == 1
+        and isinstance(node.keys[0], ast.Constant)
+        and node.keys[0].value == stage_name
+    )
+
+
+@fixer.register(ast.Call)
+def visit_Call(
+    state: State,
+    node: ast.Call,
+    parents: list[ast.AST],
+) -> Iterable[tuple[Offset, TokenFunc]]:
+    if (
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr == "parametrize"
+        and isinstance(node.func.value, ast.Attribute)
+        and node.func.value.attr == "mark"
+        and isinstance(node.func.value.value, ast.Name)
+        and node.func.value.value.id == "pytest"
+        and any((ids_node := kw).arg == "ids" for kw in node.keywords)
+        and isinstance(ids_node.value, (ast.List, ast.Tuple))
+        and print(
+            f"\n=================================\n"
+            f"bat {state.filename[2:]} -r {node.lineno}:{node.end_lineno}\n"
+            f"{subprocess.call(f'bat {state.filename[2:]} --paging always -r {node.lineno}:{node.end_lineno}',shell=True)}"
+            f"\n=================================\n"
+        )
+    ):
+        yield
+        print("That's SICK")

--- a/src/django_upgrade/fixers/parametrize_param.py
+++ b/src/django_upgrade/fixers/parametrize_param.py
@@ -1,12 +1,13 @@
 """
 Use multiple `pytest.param(..., id=...)` over `ids=[...]`
 """
+
 from __future__ import annotations
 
 import ast
 from functools import partial
-from typing import cast
 from typing import Iterable
+from typing import cast
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -15,16 +16,15 @@ from django_upgrade.ast import ast_start_offset
 from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import OP
 from django_upgrade.tokens import delete_argument
 from django_upgrade.tokens import find
 from django_upgrade.tokens import find_first_token
 from django_upgrade.tokens import find_last_token
 from django_upgrade.tokens import insert
-from django_upgrade.tokens import OP
 from django_upgrade.tokens import parse_call_args
 from django_upgrade.tokens import replace
 from django_upgrade.tokens import reverse_consume_non_semantic_elements
-
 
 fixer = Fixer(
     __name__,
@@ -39,7 +39,8 @@ def visit_Call(
     parents: list[ast.AST],
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
-        isinstance(node.func, ast.Attribute)
+        state.looks_like_test_file
+        and isinstance(node.func, ast.Attribute)
         and node.func.attr == "parametrize"
         and isinstance(node.func.value, ast.Attribute)
         and node.func.value.attr == "mark"

--- a/src/django_upgrade/fixers/parametrize_param.py
+++ b/src/django_upgrade/fixers/parametrize_param.py
@@ -5,42 +5,29 @@ https://docs.djangoproject.com/en/3.1/releases/3.1/#features-deprecated-in-3-1
 from __future__ import annotations
 
 import ast
-import subprocess
 from functools import partial
-from pprint import pprint
 from typing import Iterable
-from typing import MutableMapping
-from weakref import WeakKeyDictionary
 
-import astpretty
 from tokenize_rt import Offset
 from tokenize_rt import Token
 
 from django_upgrade.ast import ast_start_offset
-from django_upgrade.ast import is_rewritable_import_from
-from django_upgrade.compat import str_removesuffix
 from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
-from django_upgrade.tokens import CODE
+from django_upgrade.tokens import delete_argument
 from django_upgrade.tokens import find
+from django_upgrade.tokens import find_first_token
+from django_upgrade.tokens import find_last_token
 from django_upgrade.tokens import OP
+from django_upgrade.tokens import parse_call_args
 from django_upgrade.tokens import replace
-from django_upgrade.tokens import update_import_names
+
 
 fixer = Fixer(
     __name__,
     min_version=(0, 0),
 )
-
-
-def is_mongo_stage_node(node: ast.AST, stage_name: str) -> bool:
-    return (
-        isinstance(node, ast.Dict)
-        and len(node.keys) == 1
-        and isinstance(node.keys[0], ast.Constant)
-        and node.keys[0].value == stage_name
-    )
 
 
 @fixer.register(ast.Call)
@@ -58,12 +45,39 @@ def visit_Call(
         and node.func.value.value.id == "pytest"
         and any((ids_node := kw).arg == "ids" for kw in node.keywords)
         and isinstance(ids_node.value, (ast.List, ast.Tuple))
-        and print(
-            f"\n=================================\n"
-            f"bat {state.filename[2:]} -r {node.lineno}:{node.end_lineno}\n"
-            f"{subprocess.call(f'bat {state.filename[2:]} --paging always -r {node.lineno}:{node.end_lineno}',shell=True)}"
-            f"\n=================================\n"
-        )
+        and all(isinstance(id_const, ast.Constant) for id_const in ids_node.value.elts)
+        and isinstance(node.args[1], (ast.List, ast.Tuple))
+        and isinstance(node.args[1].elts[0], (ast.List, ast.Tuple))
     ):
-        yield
-        print("That's SICK")
+        yield ast_start_offset(node), partial(
+            update_parametrize_call,
+            node=node,
+            ids_node_idx=len(node.args) + node.keywords.index(ids_node),
+            ids_values=[
+                id_const.value for id_const in ids_node.value.elts  # type: ignore
+            ],
+        )
+
+
+def update_parametrize_call(
+    tokens: list[Token],
+    i: int,
+    *,
+    node: ast.Call,
+    ids_node_idx: int,
+    ids_values: list[str],
+) -> None:
+    # Delete ids list
+    j = find(tokens, i, name=OP, src="(")
+    func_args, _ = parse_call_args(tokens, j)
+    delete_argument(ids_node_idx, tokens, func_args)
+
+    # Update params
+    for param, id_value in zip(node.args[1].elts, ids_values):  # type: ignore
+        start_idx = find_first_token(tokens, i, node=param)
+        end_idx = find_last_token(tokens, j, node=param)
+
+        is_multiline = param.lineno != param.end_lineno
+        new_src = "" if (is_multiline or not param.elts) else ", "
+        replace(tokens, start_idx, src="pytest.param(")
+        replace(tokens, end_idx, src=f'{new_src}id="{id_value}")')

--- a/src/django_upgrade/tokens.py
+++ b/src/django_upgrade/tokens.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import ast
 import re
 from collections import defaultdict
-from typing import cast
 from typing import Sequence
+from typing import cast
 
 from tokenize_rt import NON_CODING_TOKENS
 from tokenize_rt import UNIMPORTANT_WS
@@ -108,13 +108,6 @@ def find_last_token(tokens: list[Token], i: int, *, node: ast.AST) -> int:
     ):
         i += 1
     return i - 1
-
-
-def reverse_consume_non_semantic_elements(tokens: list[Token], i: int) -> int:
-    """Rewind past any non-semantic tokens (PHYSICAL_NEWLINE, COMMENTS, ...)"""
-    while tokens[i - 1].name in NON_CODING_TOKENS:
-        i -= 1
-    return i
 
 
 def find_first_token_at_line(

--- a/src/django_upgrade/tokens.py
+++ b/src/django_upgrade/tokens.py
@@ -131,6 +131,13 @@ def find_first_token_at_line(
     return i
 
 
+def reverse_consume_non_semantic_elements(tokens: list[Token], i: int) -> int:
+    """Rewind past any non-semantic tokens (PHYSICAL_NEWLINE, COMMENTS, ...)"""
+    while tokens[i - 1].name in NON_CODING_TOKENS:
+        i -= 1
+    return i
+
+
 def extract_indent(tokens: list[Token], i: int) -> tuple[int, str]:
     """
     If the previous token is and indent, return its position and the

--- a/src/django_upgrade/tokens.py
+++ b/src/django_upgrade/tokens.py
@@ -4,6 +4,7 @@ import ast
 import re
 from collections import defaultdict
 from typing import cast
+from typing import Sequence
 
 from tokenize_rt import NON_CODING_TOKENS
 from tokenize_rt import UNIMPORTANT_WS
@@ -720,3 +721,19 @@ def update_import_modules(
     for module, names in reversed(imports_to_add.items()):
         joined_names = ", ".join(sorted(names))
         insert(tokens, j, new_src=f"{indent}from {module} import {joined_names}\n")
+
+
+def delete_argument(
+    i: int,
+    tokens: list[Token],
+    func_args: Sequence[tuple[int, int]],
+) -> None:
+    if i == 0:
+        # delete leading whitespace before next token
+        end_idx, _ = func_args[i + 1]
+        while tokens[end_idx].name == "UNIMPORTANT_WS":
+            end_idx += 1
+
+        del tokens[func_args[i][0] : end_idx]
+    else:
+        del tokens[func_args[i - 1][1] : func_args[i][1]]

--- a/tests/fixers/test_parametrize_param.py
+++ b/tests/fixers/test_parametrize_param.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+from functools import partial
+
 from django_upgrade.data import Settings
-from tests.fixers.tools import check_noop
-from tests.fixers.tools import check_transformed
+from tests.fixers import tools
 
 settings = Settings(target_version=(0, 0))
+check_noop = partial(tools.check_noop, settings=settings, filename="test.py")
+check_transformed = partial(
+    tools.check_transformed, settings=settings, filename="test.py"
+)
 
 
 def test_params_generated_from_func():
@@ -21,7 +26,6 @@ def test_params_generated_from_func():
         def test_check_if_responder_could_be_available(due_by, expected):
             pass
         """,
-        settings,
     )
 
 
@@ -47,7 +51,6 @@ def test_empty_ids():
         def test_check_if_responder_could_be_available(due_by, expected):
             pass
         """,
-        settings,
     )
 
 
@@ -91,7 +94,6 @@ def test_rewrite_tuple():
         def test_check_if_responder_could_be_available(due_by, expected):
             pass
         """,
-        settings,
     )
 
 
@@ -135,7 +137,6 @@ def test_rewrite_list():
         def test_check_if_responder_could_be_available(due_by, expected):
             pass
         """,
-        settings,
     )
 
 
@@ -166,7 +167,6 @@ def test_rewrite_weird_list():
         def test_check_if_responder_could_be_available(due_by, expected):
             pass
         """,
-        settings,
     )
 
 
@@ -232,7 +232,6 @@ def test_rewrite_multiline():
         def test_check_if_responder_could_be_available(due_by, expected):
             pass
         """,
-        settings,
     )
 
 
@@ -264,7 +263,6 @@ def test_rewrite_single_arg_first_arg_str():
         def test_thing(events_data, expected):
             pass
         """,
-        settings,
     )
 
 
@@ -302,7 +300,6 @@ def test_rewrite_single_arg_first_arg_str_multiline():
         def test_thing(events_data, expected):
             pass
         """,
-        settings,
     )
 
 
@@ -334,5 +331,4 @@ def test_rewrite_single_arg_first_arg_sequence_str():
         def test_thing(events_data, expected):
             pass
         """,
-        settings,
     )

--- a/tests/fixers/test_parametrize_param.py
+++ b/tests/fixers/test_parametrize_param.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from django_upgrade.data import Settings
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
+
+settings = Settings(target_version=(0, 0))
+
+
+def test_params_generated_from_func():
+    check_noop(
+        """\
+        @pytest.mark.parametrize(
+            "due_by, expected",
+            compute_params(),
+            ids=[
+                "Weekday - 7 minutes before start_hour - unavailable",
+                "Weekday - 3 minutes before start_lunch_hour - unavailable",
+            ],
+        )
+        def test_check_if_responder_could_be_available(due_by, expected):
+            pass
+        """,
+        settings,
+    )
+
+
+def test_rewrite_tuple():
+    check_transformed(
+        """\
+        import datetime as dt
+        @pytest.mark.parametrize(
+            "due_by, expected",
+            [
+                # Week day
+                (dt.date(2022, 5, 1), False),
+                (dt.date(2022, 5, 1), True),
+                (dt.date(2022, 5, 1), True),
+                # Saturday
+                (dt.date(2022, 5, 1), False),
+            ],
+            ids=[
+                "Weekday - 7 minutes",
+                "Weekday - 3 minutes",
+                "Weekday - 9 minutes",
+                "Weekday - 3 minutes",
+            ],
+        )
+        def test_check_if_responder_could_be_available(due_by, expected):
+            pass
+        """,
+        """\
+        import datetime as dt
+        @pytest.mark.parametrize(
+            "due_by, expected",
+            [
+                # Week day
+                pytest.param(dt.date(2022, 5, 1), False, id="Weekday - 7 minutes"),
+                pytest.param(dt.date(2022, 5, 1), True, id="Weekday - 3 minutes"),
+                pytest.param(dt.date(2022, 5, 1), True, id="Weekday - 9 minutes"),
+                # Saturday
+                pytest.param(dt.date(2022, 5, 1), False, id="Weekday - 3 minutes"),
+            ],
+        )
+        def test_check_if_responder_could_be_available(due_by, expected):
+            pass
+        """,
+        settings,
+    )
+
+
+def test_rewrite_list():
+    check_transformed(
+        """\
+        import datetime as dt
+        @pytest.mark.parametrize(
+            "due_by, expected",
+            [
+                # Week day
+                [dt.date(2022, 5, 1), False],
+                [dt.date(2022, 5, 1), True],
+                [dt.date(2022, 5, 1), True],
+                # Saturday
+                [dt.date(2022, 5, 1), False],
+            ],
+            ids=[
+                "Weekday - 7 minutes",
+                "Weekday - 3 minutes",
+                "Weekday - 9 minutes",
+                "Weekday - 3 minutes",
+            ],
+        )
+        def test_check_if_responder_could_be_available(due_by, expected):
+            pass
+        """,
+        """\
+        import datetime as dt
+        @pytest.mark.parametrize(
+            "due_by, expected",
+            [
+                # Week day
+                pytest.param(dt.date(2022, 5, 1), False, id="Weekday - 7 minutes"),
+                pytest.param(dt.date(2022, 5, 1), True, id="Weekday - 3 minutes"),
+                pytest.param(dt.date(2022, 5, 1), True, id="Weekday - 9 minutes"),
+                # Saturday
+                pytest.param(dt.date(2022, 5, 1), False, id="Weekday - 3 minutes"),
+            ],
+        )
+        def test_check_if_responder_could_be_available(due_by, expected):
+            pass
+        """,
+        settings,
+    )
+
+
+def test_rewrite_multiline():
+    check_transformed(
+        """\
+        import datetime as dt
+        @pytest.mark.parametrize(
+            "due_by, expected",
+            [
+                # Week day
+                [
+                    dt.date(2022, 5, 1),
+                    False,
+                ],
+                [
+                    dt.date(2022, 5, 1),
+                    True,
+                ],
+            ],
+            ids=[
+                "Weekday - 7 minutes",
+                "Weekday - 3 minutes",
+            ],
+        )
+        def test_check_if_responder_could_be_available(due_by, expected):
+            pass
+        """,
+        """\
+        import datetime as dt
+        @pytest.mark.parametrize(
+            "due_by, expected",
+            [
+                # Week day
+                pytest.param(
+                    dt.date(2022, 5, 1),
+                    False,
+                id="Weekday - 7 minutes"),
+                pytest.param(
+                    dt.date(2022, 5, 1),
+                    True,
+                id="Weekday - 3 minutes"),
+            ],
+        )
+        def test_check_if_responder_could_be_available(due_by, expected):
+            pass
+        """,
+        settings,
+    )
+
+
+def test_rewrite_single_arg():
+    check_transformed(
+        """\
+        @pytest.mark.parametrize(
+            "events_data",
+            [
+                [1, 2],
+                [],
+            ],
+            ids=[
+                "2 events",
+                "No events",
+            ],
+        )
+        def test_thing(events_data, expected):
+            pass
+        """,
+        """\
+        @pytest.mark.parametrize(
+            "events_data",
+            [
+                pytest.param(1, 2, id="2 events"),
+                pytest.param(id="No events"),
+            ],
+        )
+        def test_thing(events_data, expected):
+            pass
+        """,
+        settings,
+    )

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -7,9 +7,9 @@ from tokenize_rt import Token
 from tokenize_rt import src_to_tokens
 from tokenize_rt import tokens_to_src
 
+from django_upgrade.tokens import OP
 from django_upgrade.tokens import delete_argument
 from django_upgrade.tokens import find
-from django_upgrade.tokens import OP
 from django_upgrade.tokens import parse_call_args
 from django_upgrade.tokens import str_repr_matching
 from django_upgrade.tokens import update_import_names

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -7,6 +7,10 @@ from tokenize_rt import Token
 from tokenize_rt import src_to_tokens
 from tokenize_rt import tokens_to_src
 
+from django_upgrade.tokens import delete_argument
+from django_upgrade.tokens import find
+from django_upgrade.tokens import OP
+from django_upgrade.tokens import parse_call_args
 from django_upgrade.tokens import str_repr_matching
 from django_upgrade.tokens import update_import_names
 
@@ -123,3 +127,26 @@ class TestUpdateImportNames:
             name_map={"b": "", "c": ""},
             after="from a import d",
         )
+
+
+@pytest.mark.parametrize(
+    "before, delete_idx, after",
+    (
+        ("call(ids=1, test=2)", 0, "call(test=2)"),
+        ("call(ids=1, test=2)", 1, "call(ids=1)"),
+        ("call(ids=1, \ntest=2)", 1, "call(ids=1)"),
+        ("call(\nids=1, \ntest=2)", 1, "call(\nids=1)"),
+        (
+            "call(\n \nids= 1 \n   \n,\n  \ntest = 2\n\n )",
+            0,
+            "call(\n  \ntest = 2\n\n )",
+        ),
+    ),
+)
+def test_delete_arguments(before, delete_idx, after):
+    tokens, mod = tokenize_and_parse(before)
+    j = find(tokens, 0, name=OP, src="(")
+    func_args, _ = parse_call_args(tokens, j)
+    delete_argument(delete_idx, tokens, func_args)
+
+    assert tokens_to_src(tokens) == after


### PR DESCRIPTION
## What it does

Checks for `pytest.mark.parametrize` calls using the `ids` keyword argument and replace each set of test values with a `pytest.params(.., id=...)` parameter set, effectively binding the `id` with the set of arguments.

## Why is this bad?

When using the `ids=[…] syntax`, each id is bound to a set of parameters **by index**.

This is quite error prone and makes test hard to modify (adding a test case in the middle means adding an id at the corresponding index in the ids list). Moreover, if one test case fails, it's not directly obvious which set of parameters is associated with the failing id. This issue gets worse the more test case you have in your parametrize call.

## Example
```python
@pytest.mark.parametrize(
    "a, b, expected",
    [
        (datetime(2001, 12, 12), datetime(2001, 12, 11), timedelta(1)),
        ... # 10 other test cases
        (datetime(2001, 12, 11), datetime(2001, 12, 12), timedelta(-1)),
    ],
    ids=["forward", ..., "backward"],
)
def test(a, b, expected):
    pass
```

Use instead:
```python
@pytest.mark.parametrize(
    "a, b, expected",
    [
        pytest.param(
            datetime(2001, 12, 12), datetime(2001, 12, 11), timedelta(1), id="forward"
        ),
        ... # 10 other test cases
        pytest.param(
            datetime(2001, 12, 11), datetime(2001, 12, 12), timedelta(-1), id="backward"
        ),
    ],
)
def test(a, b, expected):
    pass
```