### PR TITLE
Always use lazy relationships when defining `ForeignKey`/`ManyToMany` fields

### DIFF
--- a/src/django_upgrade/data.py
+++ b/src/django_upgrade/data.py
@@ -125,10 +125,7 @@ def visit(
         if (
             isinstance(node, ast.ImportFrom)
             and node.level == 0
-            and (
-                node.module is not None
-                and (node.module.startswith("django.") or node.module == "django")
-            )
+            and node.module is not None
         ):
             state.from_imports[node.module].update(
                 name.name

--- a/src/django_upgrade/fixers/model_relationship_as_str.py
+++ b/src/django_upgrade/fixers/model_relationship_as_str.py
@@ -1,0 +1,54 @@
+"""
+"""
+from __future__ import annotations
+
+import ast
+import os
+from functools import partial
+from typing import Iterable
+
+from tokenize_rt import Offset
+
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.ast import is_name_attr
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import replace
+
+fixer = Fixer(
+    __name__,
+    min_version=(0, 0),
+)
+
+
+@fixer.register(ast.Call)
+def visit_Call(
+    state: State,
+    node: ast.Call,
+    parents: list[ast.AST],
+) -> Iterable[tuple[Offset, TokenFunc]]:
+    if (
+        is_name_attr(
+            node=node.func,
+            imports=state.from_imports,
+            mods=("models",),
+            names={"ForeignKey", "ManyToManyField", "OneToOneField"},
+        )
+        and len(node.args) > 0
+    ):
+        if isinstance((related_model := node.args[0]), ast.Name):
+            for module, names in state.from_imports.items():
+                if related_model.id in names and "django." not in module:
+                    new_str = f"{module.rpartition('.models')[0]}.{related_model.id}"
+                    yield ast_start_offset(related_model), partial(
+                        replace, src=f'"{new_str}"'
+                    )
+        elif (
+            isinstance((related_model := node.args[0]), ast.Constant)
+            and related_model.value != "self"
+            and "." not in related_model.value
+        ):
+            app_name = os.path.normpath(state.filename).rpartition("/models")[0]
+            new_str = f"{app_name}.{related_model.value}"
+            yield ast_start_offset(related_model), partial(replace, src=f'"{new_str}"')

--- a/tests/fixers/test_model_relationship_as_str.py
+++ b/tests/fixers/test_model_relationship_as_str.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from django_upgrade.data import Settings
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
+
+settings = Settings(target_version=(5, 0))
+
+
+def test_noop_django_models():
+    check_noop(
+        """\
+        from django.contrib.auth.models import Group
+        class MyModel(models.Model):
+            group = models.ForeignKey(Group, on_delete=models.SET_NULL)
+        """,
+        settings,
+    )
+
+
+def test_noop_fk_defined_in_same_file():
+    check_noop(
+        """\
+        class Category(models.Model):
+            name = models.CharField(max_length=12)
+
+        class Article(models.Model):
+            category = models.ForeignKey(Category, on_delete=models.SET_NULL)
+        """,
+        settings,
+    )
+
+
+def test_transform_simple_import():
+    check_transformed(
+        """\
+        from core.models import User
+        class MyModel(models.Model):
+            user = models.ForeignKey(User, on_delete=models.SET_NULL)
+            user2 = models.OneToOneField(User, on_delete=models.SET_NULL)
+            users = models.ManyToManyField(User, on_delete=models.SET_NULL)
+        """,
+        """\
+        from core.models import User
+        class MyModel(models.Model):
+            user = models.ForeignKey("core.User", on_delete=models.SET_NULL)
+            user2 = models.OneToOneField("core.User", on_delete=models.SET_NULL)
+            users = models.ManyToManyField("core.User", on_delete=models.SET_NULL)
+        """,
+        settings,
+    )
+
+
+def test_transform_absolute_import():
+    check_transformed(
+        """\
+        from core.models.user import User
+        from core.models.weird.weirdo import WeirdUser
+        class MyModel(models.Model):
+            user = models.ForeignKey(User, on_delete=models.SET_NULL)
+            weird_user = models.ForeignKey(WeirdUser, on_delete=models.SET_NULL)
+        """,
+        """\
+        from core.models.user import User
+        from core.models.weird.weirdo import WeirdUser
+        class MyModel(models.Model):
+            user = models.ForeignKey("core.User", on_delete=models.SET_NULL)
+            weird_user = models.ForeignKey("core.WeirdUser", on_delete=models.SET_NULL)
+        """,
+        settings,
+    )
+
+
+def test_transform_inferred_app_name():
+    check_transformed(
+        """\
+        class MyModel(models.Model):
+            user = models.ForeignKey("User", on_delete=models.SET_NULL)
+        """,
+        """\
+        class MyModel(models.Model):
+            user = models.ForeignKey("core.User", on_delete=models.SET_NULL)
+        """,
+        settings,
+        filename="core/models/mymodels.py",
+    )
+
+
+def test_noop_self():
+    check_noop(
+        """\
+        class MyModel(models.Model):
+            group = models.ForeignKey("self", on_delete=models.SET_NULL)
+        """,
+        settings,
+        filename="core/models/mymodels.py",
+    )


### PR DESCRIPTION
It is a common issue in django to face circular import when defining foreign keys like that:

```python
from myapp.models import House

class MyModel(models.Model):
    house = models.ForeignKey(House, null=False, on_delete=models.CASCADE)
```

One easy workaround [django provides](https://docs.djangoproject.com/en/3.2/ref/models/fields/#foreignkey) is to use a lazy relationship:
```diff
from myapp.models import House

class MyModel(models.Model):
-    house = models.ForeignKey(House, null=False, on_delete=models.CASCADE)
+    house = models.ForeignKey("myapp.House", null=False, on_delete=models.CASCADE)
```
Django documentation exemples are also always using this style so it seems like the recommanded way.

Autofixing to a string syntax is quite easy. The information needed is available in the import statement.
Deleting the import is however more complicated as it requires to know if the import is unused. I've chosen to defer the import cleanup to any external linter one could be using.

This fixer also add explicit app name, mostly for consistency and to resolve issues people usually have with mypy + django-stubs:

```diff
# file: mysite/myapp/models.py
class MyModel(models.Model):
-    house = models.ForeignKey("House", null=False, on_delete=models.CASCADE)
+    house = models.ForeignKey("myapp.House", null=False, on_delete=models.CASCADE)
```