### PR TITLE
Remove redundant `select_related` / `prefetch_related` fields

### DIFF
--- a/src/django_upgrade/fixers/model_relationship_as_str.py
+++ b/src/django_upgrade/fixers/model_relationship_as_str.py
@@ -1,5 +1,6 @@
 """
 """
+
 from __future__ import annotations
 
 import ast

--- a/src/django_upgrade/fixers/signal_providing_args.py
+++ b/src/django_upgrade/fixers/signal_providing_args.py
@@ -18,13 +18,10 @@ from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
 from django_upgrade.tokens import CODE
-from django_upgrade.tokens import COMMENT
-from django_upgrade.tokens import INDENT
-from django_upgrade.tokens import OP
-from django_upgrade.tokens import consume
 from django_upgrade.tokens import find
+from django_upgrade.tokens import OP
 from django_upgrade.tokens import parse_call_args
-from django_upgrade.tokens import reverse_consume
+from django_upgrade.tokens import remove_arg
 
 fixer = Fixer(
     __name__,
@@ -73,18 +70,6 @@ def remove_providing_args(tokens: list[Token], i: int, *, node: ast.Call) -> Non
     else:
         for n, keyword in enumerate(node.keywords):
             if keyword.arg == "providing_args":
-                start_idx, end_idx = func_args[n]
-
-                start_idx = reverse_consume(tokens, start_idx, name=UNIMPORTANT_WS)
-                start_idx = reverse_consume(tokens, start_idx, name=INDENT)
-                if n > 0:
-                    start_idx = reverse_consume(tokens, start_idx, name=OP, src=",")
-
-                if n < len(node.keywords) - 1:
-                    end_idx = consume(tokens, end_idx, name=UNIMPORTANT_WS)
-                    end_idx = consume(tokens, end_idx, name=OP, src=",")
-                    end_idx = consume(tokens, end_idx, name=UNIMPORTANT_WS)
-                    end_idx = consume(tokens, end_idx, name=COMMENT)
-                    end_idx += 1
-
-                del tokens[start_idx:end_idx]
+                remove_arg(
+                    tokens, func_args=func_args, arg_idx_to_remove=len(node.args) + n
+                )

--- a/src/django_upgrade/fixers/signal_providing_args.py
+++ b/src/django_upgrade/fixers/signal_providing_args.py
@@ -9,7 +9,6 @@ import ast
 from functools import partial
 from typing import Iterable
 
-from tokenize_rt import UNIMPORTANT_WS
 from tokenize_rt import Offset
 from tokenize_rt import Token
 
@@ -18,8 +17,8 @@ from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
 from django_upgrade.tokens import CODE
-from django_upgrade.tokens import find
 from django_upgrade.tokens import OP
+from django_upgrade.tokens import find
 from django_upgrade.tokens import parse_call_args
 from django_upgrade.tokens import remove_arg
 

--- a/src/django_upgrade/fixers/signal_providing_args.py
+++ b/src/django_upgrade/fixers/signal_providing_args.py
@@ -58,18 +58,16 @@ def visit_Call(
 
 def remove_providing_args(tokens: list[Token], i: int, *, node: ast.Call) -> None:
     j = find(tokens, i, name=OP, src="(")
-    func_args, _ = parse_call_args(tokens, j)
+    func_args, end_idx = parse_call_args(tokens, j)
 
     if len(node.args):
-        start_idx, end_idx = func_args[0]
         if len(node.args) == 1:
-            del tokens[start_idx:end_idx]
+            remove_arg(tokens, func_args, end_idx, arg_idx=0)
         else:
             # Have to replace with None
+            start_idx, end_idx = func_args[0]
             tokens[start_idx:end_idx] = [Token(name=CODE, src="None")]
     else:
         for n, keyword in enumerate(node.keywords):
             if keyword.arg == "providing_args":
-                remove_arg(
-                    tokens, func_args=func_args, arg_idx_to_remove=len(node.args) + n
-                )
+                remove_arg(tokens, func_args, end_idx, arg_idx=n)

--- a/src/django_upgrade/fixers/simplify_select_prefetch_related.py
+++ b/src/django_upgrade/fixers/simplify_select_prefetch_related.py
@@ -69,7 +69,7 @@ def simplify_related_lookup(
     tokens: list[Token], i: int, *, args_idx_to_remove: list[int]
 ) -> None:
     open_idx = reverse_find(tokens, i, name=OP, src="(")
-    func_args, _ = parse_call_args(tokens, open_idx)
+    func_args, end_idx = parse_call_args(tokens, open_idx)
 
     for arg_idx in sorted(args_idx_to_remove, reverse=True):
-        remove_arg(tokens, func_args=func_args, arg_idx_to_remove=arg_idx)
+        remove_arg(tokens, func_args, end_idx, arg_idx=arg_idx)

--- a/src/django_upgrade/fixers/simplify_select_prefetch_related.py
+++ b/src/django_upgrade/fixers/simplify_select_prefetch_related.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import ast
+from functools import partial
+from typing import Dict
+from typing import Iterable
+
+from tokenize_rt import Offset
+from tokenize_rt import Token
+
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import OP
+from django_upgrade.tokens import parse_call_args
+from django_upgrade.tokens import remove_arg
+from django_upgrade.tokens import reverse_find
+
+fixer = Fixer(
+    __name__,
+    min_version=(0, 0),
+)
+
+NestedDict = Dict[str, "NestedDict"]
+
+
+@fixer.register(ast.Call)
+def visit_Call(
+    state: State,
+    node: ast.Call,
+    parents: list[ast.AST],
+) -> Iterable[tuple[Offset, TokenFunc]]:
+    if (
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr in {"select_related", "prefetch_related"}
+        and not node.keywords
+        and len(node.args) > 1
+        and any(
+            isinstance(arg, ast.Constant) and "__" in arg.value for arg in node.args
+        )
+    ):
+        fields = sorted(
+            (
+                (arg.value, idx)
+                for idx, arg in enumerate(node.args)
+                if isinstance(arg, ast.Constant)
+            ),
+            key=lambda k: len(k[0]),
+            reverse=True,
+        )
+
+        args_idx_to_remove = []
+        field_dict: NestedDict = {}
+        for field, arg_idx in fields:
+            d = field_dict
+            for part in field.split("__"):
+                d = d.setdefault(part, {})
+            if d != {}:
+                args_idx_to_remove.append(arg_idx)
+
+        if args_idx_to_remove:
+            yield ast_start_offset(node.args[0]), partial(
+                simplify_related_lookup, args_idx_to_remove=args_idx_to_remove
+            )
+
+
+def simplify_related_lookup(
+    tokens: list[Token], i: int, *, args_idx_to_remove: list[int]
+) -> None:
+    open_idx = reverse_find(tokens, i, name=OP, src="(")
+    func_args, _ = parse_call_args(tokens, open_idx)
+
+    for arg_idx in sorted(args_idx_to_remove, reverse=True):
+        remove_arg(tokens, func_args=func_args, arg_idx_to_remove=arg_idx)

--- a/src/django_upgrade/tokens.py
+++ b/src/django_upgrade/tokens.py
@@ -416,6 +416,18 @@ def remove_arg(
         end_idx = consume(tokens, end_idx, name=UNIMPORTANT_WS)
         end_idx = consume(tokens, end_idx, name=COMMENT)
         end_idx += 1
+
+        if arg_idx == 0:
+            # Preserve comment between open paren and first argument.
+            start_idx = consume(tokens, start_idx - 1, name=UNIMPORTANT_WS) + 1
+            start_idx = consume(tokens, start_idx - 1, name=COMMENT) + 1
+            if tokens[start_idx].name == PHYSICAL_NEWLINE:
+                start_idx += 1
+                start_idx = consume(tokens, start_idx - 1, name=UNIMPORTANT_WS) + 1
+            if tokens[end_idx].name == PHYSICAL_NEWLINE:
+                end_idx += 1
+                end_idx = consume(tokens, end_idx - 1, name=UNIMPORTANT_WS) + 1
+
         del tokens[start_idx:end_idx]
 
     else:

--- a/src/django_upgrade/tokens.py
+++ b/src/django_upgrade/tokens.py
@@ -393,6 +393,36 @@ def replace_argument_names(
                 raise AssertionError(f"{keyword.arg} argument not found")
 
 
+def remove_arg(
+    tokens: list[Token],
+    *,
+    func_args: list[tuple[int, int]],
+    arg_idx_to_remove: int,
+) -> None:
+    nb_args = len(func_args)
+    start_idx, end_idx = func_args[arg_idx_to_remove]
+
+    if nb_args == 1:
+        # Argument is the only node.
+        del tokens[start_idx:end_idx]
+
+    elif arg_idx_to_remove + 1 != nb_args:
+        # Argument is not the last node.
+        # Delete from the argument start until the next comma.
+        end_idx = find(tokens, end_idx, name=OP, src=",")
+        end_idx = consume(tokens, end_idx, name=UNIMPORTANT_WS)
+        end_idx = consume(tokens, end_idx, name=COMMENT)
+        end_idx += 1
+        del tokens[start_idx:end_idx]
+
+    elif arg_idx_to_remove + 1 == nb_args:
+        # Argument is the last node.
+        # Delete from the previous comma to the argument end.
+        _, previous_end_idx = func_args[arg_idx_to_remove - 1]
+        start_idx = find(tokens, previous_end_idx, name=OP, src=",")
+        del tokens[start_idx:end_idx]
+
+
 str_repr_single_to_double = str.maketrans(
     {
         "'": '"',

--- a/tests/fixers/test_signal_providing_args.py
+++ b/tests/fixers/test_signal_providing_args.py
@@ -42,7 +42,6 @@ def test_pos_arg_alone_trailing_comma():
         from django.dispatch import Signal
         Signal()
         """,
-        settings,
     )
 
 

--- a/tests/fixers/test_signal_providing_args.py
+++ b/tests/fixers/test_signal_providing_args.py
@@ -172,7 +172,7 @@ def test_kwarg_with_all_extras():
         """\
         from django.dispatch import Signal
         Signal(
-            use_caching=True,
+              use_caching=True,
         )
         """,
     )

--- a/tests/fixers/test_signal_providing_args.py
+++ b/tests/fixers/test_signal_providing_args.py
@@ -32,6 +32,20 @@ def test_pos_arg_alone():
     )
 
 
+def test_pos_arg_alone_trailing_comma():
+    check_transformed(
+        """\
+        from django.dispatch import Signal
+        Signal(["documented", "arg"],)
+        """,
+        """\
+        from django.dispatch import Signal
+        Signal()
+        """,
+        settings,
+    )
+
+
 def test_pos_arg_alone_module_imported():
     check_transformed(
         """\

--- a/tests/fixers/test_simplify_select_prefetch_related.py
+++ b/tests/fixers/test_simplify_select_prefetch_related.py
@@ -48,7 +48,7 @@ def test_transform_three_level():
         """,
         """\
         MyModel.objects.select_related(
-            "category__best_article__author",
+            "category__best_article__author"
         )
         """,
         settings,
@@ -68,7 +68,22 @@ def test_transform_multiline():
         """\
         MyModel.objects.select_related(
             "variables__variablevalues",
-            "category__best_article",
+            "category__best_article"
+        )
+        """,
+        settings,
+    )
+
+
+def test_transform_arg_on_single_line():
+    check_transformed(
+        """\
+        MyModel.objects.select_related(
+            "category", "variables__bla", "category__best_article", "variables",
+        )
+        """,
+        """\
+        MyModel.objects.select_related("variables__bla", "category__best_article"
         )
         """,
         settings,

--- a/tests/fixers/test_simplify_select_prefetch_related.py
+++ b/tests/fixers/test_simplify_select_prefetch_related.py
@@ -40,14 +40,14 @@ def test_transform():
 def test_transform_three_level():
     check_transformed(
         """\
-        MyModel.objects.select_related(
+        MyModel.objects.select_related( # Comment
             "category__best_article",
             "category__best_article__author",
             "category",
         )
         """,
         """\
-        MyModel.objects.select_related(
+        MyModel.objects.select_related( # Comment
             "category__best_article__author"
         )
         """,
@@ -75,15 +75,32 @@ def test_transform_multiline():
     )
 
 
-def test_transform_arg_on_single_line():
+def test_transform_mixed_line():
     check_transformed(
         """\
-        MyModel.objects.select_related(
+        MyModel.objects.select_related(  # Very important comment
             "category", "variables__bla", "category__best_article", "variables",
         )
         """,
         """\
-        MyModel.objects.select_related("variables__bla", "category__best_article"
+        MyModel.objects.select_related(  # Very important comment
+            "variables__bla", "category__best_article"
+        )
+        """,
+        settings,
+    )
+
+
+def test_transform_mixed_line_2_args():
+    check_transformed(
+        """\
+        MyModel.objects.select_related(  # Very important comment
+            "category", "category__best_article"
+        )
+        """,
+        """\
+        MyModel.objects.select_related(  # Very important comment
+            "category__best_article"
         )
         """,
         settings,

--- a/tests/fixers/test_simplify_select_prefetch_related.py
+++ b/tests/fixers/test_simplify_select_prefetch_related.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from django_upgrade.data import Settings
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
+
+settings = Settings(target_version=(5, 0))
+
+
+def test_noop_wrong_chain_order():
+    check_noop(
+        """\
+        MyModel.objects.select_related("category", "best_article__category")
+        """,
+        settings,
+    )
+
+
+def test_noop_single_underscore():
+    check_noop(
+        """\
+        MyModel.objects.select_related("category", "category_name")
+        """,
+        settings,
+    )
+
+
+def test_transform():
+    check_transformed(
+        """\
+        MyModel.objects.select_related("category", "category__best_article")
+        """,
+        """\
+        MyModel.objects.select_related("category__best_article")
+        """,
+        settings,
+    )
+
+
+def test_transform_three_level():
+    check_transformed(
+        """\
+        MyModel.objects.select_related(
+            "category__best_article",
+            "category__best_article__author",
+            "category",
+        )
+        """,
+        """\
+        MyModel.objects.select_related(
+            "category__best_article__author",
+        )
+        """,
+        settings,
+    )
+
+
+def test_transform_multiline():
+    check_transformed(
+        """\
+        MyModel.objects.select_related(
+            "variables__variablevalues",
+            "category",
+            "category__best_article",
+            "variables",
+        )
+        """,
+        """\
+        MyModel.objects.select_related(
+            "variables__variablevalues",
+            "category__best_article",
+        )
+        """,
+        settings,
+    )
+
+
+def test_transform_multiline_chained_qs():
+    check_transformed(
+        """\
+        my_model = (
+            MyModel.objects.filter(identifier="aaa")
+            .select_related("category", "category__best_article")
+            .only(
+                "identifier",
+                "category_id",
+                "category__best_article__id",
+            )
+            .first()
+        )
+        """,
+        """\
+        my_model = (
+            MyModel.objects.filter(identifier="aaa")
+            .select_related("category__best_article")
+            .only(
+                "identifier",
+                "category_id",
+                "category__best_article__id",
+            )
+            .first()
+        )
+        """,
+        settings,
+    )
+
+
+def test_transform_with_var():
+    check_transformed(
+        """\
+        to_select = "aa"
+        MyModel.objects.select_related(to_select, "category", "category__best_article")
+        """,
+        """\
+        to_select = "aa"
+        MyModel.objects.select_related(to_select,"category__best_article")
+        """,
+        settings,
+    )


### PR DESCRIPTION
De duplication is already done internally (especially because it could lead to duplicate work in the prefetch related case).

See [prefetch_related_objects](https://github.com/django/django/blob/c83c639ba0c67dbb0f627be3df29d1224ea92d2b/django/db/models/query.py#L2278) for prefetch_related

See [add_select_related](https://github.com/django/django/blob/c83c639ba0c67dbb0f627be3df29d1224ea92d2b/django/db/models/sql/query.py#L2305) for select_related.

```diff
-Book.objects.select_related("author", "author__hometown")
+Book.objects.select_related("author__hometown")

-Book.objects.prefetch_related("additional_data", "additional_data__children")
+Book.objects.prefetch_related("additional_data__children")
```