### PR TITLE
Simplify some `django.utils.timezone` usages

### DIFF
--- a/src/django_upgrade/fixers/utils_timezone_simplifications.py
+++ b/src/django_upgrade/fixers/utils_timezone_simplifications.py
@@ -12,9 +12,9 @@ from django_upgrade.ast import is_name_attr
 from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import OP
 from django_upgrade.tokens import find
 from django_upgrade.tokens import find_and_replace_name
-from django_upgrade.tokens import OP
 from django_upgrade.tokens import parse_call_args
 
 fixer = Fixer(
@@ -32,7 +32,7 @@ def visit_Call(
     if is_name_attr(
         node=node.func,
         imports=state.from_imports,
-        mods=("timezone",),
+        mods=("timezone", "django.utils.timezone"),
         names={"localdate", "localtime"},
     ):
         # `timezone.localdate(timezone.now())` -> `timezone.localdate()`
@@ -43,7 +43,7 @@ def visit_Call(
             and is_name_attr(
                 node=node.args[0].func,
                 imports=state.from_imports,
-                mods=("timezone",),
+                mods=("timezone", "django.utils.timezone"),
                 names={"now"},
             )
         ):
@@ -66,7 +66,7 @@ def visit_Call(
         is_name_attr(
             node=node.func,
             imports=state.from_imports,
-            mods=("timezone",),
+            mods=("timezone", "django.utils.timezone"),
             names={"make_aware"},
         )
         and len(node.args) == 1

--- a/src/django_upgrade/fixers/utils_timezone_simplifications.py
+++ b/src/django_upgrade/fixers/utils_timezone_simplifications.py
@@ -13,6 +13,7 @@ from django_upgrade.data import Fixer
 from django_upgrade.data import State
 from django_upgrade.data import TokenFunc
 from django_upgrade.tokens import find
+from django_upgrade.tokens import find_and_replace_name
 from django_upgrade.tokens import OP
 from django_upgrade.tokens import parse_call_args
 
@@ -28,26 +29,48 @@ def visit_Call(
     node: ast.Call,
     parents: list[ast.AST],
 ) -> Iterable[tuple[Offset, TokenFunc]]:
-    if (
-        is_name_attr(
-            node=node.func,
-            imports=state.from_imports,
-            mods=("timezone",),
-            names={"localdate", "localtime"},
-        )
-        and len(node.args) == 1
-        and isinstance(node.args[0], ast.Call)
-        and is_name_attr(
-            node=node.args[0].func,
-            imports=state.from_imports,
-            mods=("timezone",),
-            names={"now"},
-        )
+    if is_name_attr(
+        node=node.func,
+        imports=state.from_imports,
+        mods=("timezone",),
+        names={"localdate", "localtime"},
     ):
-        yield ast_start_offset(node), partial(remove_call_args)
+        # `timezone.localdate(timezone.now())` -> `timezone.localdate()`
+        # `timezone.localtime(timezone.now())` -> `timezone.localtime()`
+        if (
+            len(node.args) == 1
+            and isinstance(node.args[0], ast.Call)
+            and is_name_attr(
+                node=node.args[0].func,
+                imports=state.from_imports,
+                mods=("timezone",),
+                names={"now"},
+            )
+        ):
+            yield ast_start_offset(node), partial(remove_call_args)
+
+        # `timezone.localtime(...).date()` -> `timezone.localdate()`
+        if (
+            isinstance(parents[-1], ast.Attribute)
+            and parents[-1].attr == "date"
+            and isinstance(parents[-2], ast.Call)
+            and not parents[-2].args
+            and not parents[-2].keywords
+        ):
+            yield ast_start_offset(node), partial(
+                find_and_replace_name, name="localtime", new="localdate"
+            )
+            yield ast_start_offset(node), partial(remove_attr_call)
 
 
 def remove_call_args(tokens: list[Token], i: int) -> None:
     open_idx = find(tokens, i, name=OP, src="(")
     func_args, close_idx = parse_call_args(tokens, open_idx)
     del tokens[open_idx + 1 : close_idx - 1]
+
+
+def remove_attr_call(tokens: list[Token], i: int) -> None:
+    open_idx = find(tokens, i, name=OP, src="(")
+    func_args, close_idx = parse_call_args(tokens, open_idx)
+    attr_call_close_idx = find(tokens, close_idx, name=OP, src=")")
+    del tokens[close_idx : attr_call_close_idx + 1]

--- a/src/django_upgrade/fixers/utils_timezone_simplifications.py
+++ b/src/django_upgrade/fixers/utils_timezone_simplifications.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import ast
+from functools import partial
+from typing import Iterable
+
+from tokenize_rt import Offset
+from tokenize_rt import Token
+
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.ast import is_name_attr
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import find
+from django_upgrade.tokens import OP
+from django_upgrade.tokens import parse_call_args
+
+fixer = Fixer(
+    __name__,
+    min_version=(0, 0),
+)
+
+
+@fixer.register(ast.Call)
+def visit_Call(
+    state: State,
+    node: ast.Call,
+    parents: list[ast.AST],
+) -> Iterable[tuple[Offset, TokenFunc]]:
+    if (
+        is_name_attr(
+            node=node.func,
+            imports=state.from_imports,
+            mods=("timezone",),
+            names={"localdate", "localtime"},
+        )
+        and len(node.args) == 1
+        and isinstance(node.args[0], ast.Call)
+        and is_name_attr(
+            node=node.args[0].func,
+            imports=state.from_imports,
+            mods=("timezone",),
+            names={"now"},
+        )
+    ):
+        yield ast_start_offset(node), partial(remove_call_args)
+
+
+def remove_call_args(tokens: list[Token], i: int) -> None:
+    open_idx = find(tokens, i, name=OP, src="(")
+    func_args, close_idx = parse_call_args(tokens, open_idx)
+    del tokens[open_idx + 1 : close_idx - 1]

--- a/tests/fixers/test_utils_timezone_simplifications.py
+++ b/tests/fixers/test_utils_timezone_simplifications.py
@@ -10,8 +10,12 @@ settings = Settings(target_version=(5, 0))
 def test_noop():
     check_noop(
         """\
+        from django.utils import timezone
+        import datetime as dt
 
-
+        timezone.localtime(timezone.make_aware(dt.datetime(2022, 1, 1)))
+        my_date = timezone.make_aware(dt.datetime(2022, 1, 1))
+        timezone.localdate(my_date)
         """,
         settings,
     )
@@ -20,9 +24,13 @@ def test_noop():
 def test_transform_unnecessary_localtime_default():
     check_transformed(
         """\
+        from django.utils import timezone
+
         timezone.localtime(timezone.now())
         """,
         """\
+        from django.utils import timezone
+
         timezone.localtime()
         """,
         settings,
@@ -32,10 +40,14 @@ def test_transform_unnecessary_localtime_default():
 def test_transform_unnecessary_localdate_default():
     check_transformed(
         """\
+        from django.utils import timezone
+
         timezone.localdate(timezone.now())
         """,
         """\
-        timezone.localtime()
+        from django.utils import timezone
+
+        timezone.localdate()
         """,
         settings,
     )
@@ -44,6 +56,8 @@ def test_transform_unnecessary_localdate_default():
 def test_transform_unnecessary_localtime_default_multiline():
     check_transformed(
         """\
+        from django.utils import timezone
+
         timezone.localtime(
             timezone.now()
         )
@@ -51,6 +65,8 @@ def test_transform_unnecessary_localtime_default_multiline():
         timezone.now())
         """,
         """\
+        from django.utils import timezone
+
         timezone.localtime()
         timezone.localdate()
         """,
@@ -61,10 +77,14 @@ def test_transform_unnecessary_localtime_default_multiline():
 def test_transform_localdate_instead_of_localtime():
     check_transformed(
         """\
+        from django.utils import timezone
+
         timezone.localtime(timezone.now()).date()
         timezone.localtime().date()
         """,
         """\
+        from django.utils import timezone
+
         timezone.localdate()
         timezone.localdate()
         """,
@@ -75,10 +95,52 @@ def test_transform_localdate_instead_of_localtime():
 def test_transform_localdate_instead_of_localtime_with_date():
     check_transformed(
         """\
+        from django.utils import timezone
+        import datetime as dt
+
         timezone.localtime(timezone.make_aware(dt.datetime(2022, 1, 1))).date()
         """,
         """\
+        from django.utils import timezone
+        import datetime as dt
+
         timezone.localdate(timezone.make_aware(dt.datetime(2022, 1, 1)))
+        """,
+        settings,
+    )
+
+
+def test_transform_overcomplicated_localtime_dt_datetime():
+    check_transformed(
+        """\
+        from django.utils import timezone
+        import datetime as dt
+
+        timezone.make_aware(dt.datetime.now())
+        """,
+        """\
+        from django.utils import timezone
+        import datetime as dt
+
+        timezone.localtime()
+        """,
+        settings,
+    )
+
+
+def test_transform_overcomplicated_localtime_datetime():
+    check_transformed(
+        """\
+        from django.utils import timezone
+        from datetime import datetime
+
+        timezone.make_aware(datetime.now())
+        """,
+        """\
+        from django.utils import timezone
+        from datetime import datetime
+
+        timezone.localtime()
         """,
         settings,
     )

--- a/tests/fixers/test_utils_timezone_simplifications.py
+++ b/tests/fixers/test_utils_timezone_simplifications.py
@@ -58,13 +58,27 @@ def test_transform_unnecessary_localtime_default_multiline():
     )
 
 
-def test_transform_conplicated_localtime():
+def test_transform_localdate_instead_of_localtime():
     check_transformed(
         """\
-        timezone.make_aware(dt.datetime.now())
+        timezone.localtime(timezone.now()).date()
+        timezone.localtime().date()
         """,
         """\
-        timezone.localtime()
+        timezone.localdate()
+        timezone.localdate()
+        """,
+        settings,
+    )
+
+
+def test_transform_localdate_instead_of_localtime_with_date():
+    check_transformed(
+        """\
+        timezone.localtime(timezone.make_aware(dt.datetime(2022, 1, 1))).date()
+        """,
+        """\
+        timezone.localdate(timezone.make_aware(dt.datetime(2022, 1, 1)))
         """,
         settings,
     )

--- a/tests/fixers/test_utils_timezone_simplifications.py
+++ b/tests/fixers/test_utils_timezone_simplifications.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from django_upgrade.data import Settings
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
+
+settings = Settings(target_version=(5, 0))
+
+
+def test_noop():
+    check_noop(
+        """\
+
+
+        """,
+        settings,
+    )
+
+
+def test_transform_unnecessary_localtime_default():
+    check_transformed(
+        """\
+        timezone.localtime(timezone.now())
+        """,
+        """\
+        timezone.localtime()
+        """,
+        settings,
+    )
+
+
+def test_transform_unnecessary_localdate_default():
+    check_transformed(
+        """\
+        timezone.localdate(timezone.now())
+        """,
+        """\
+        timezone.localtime()
+        """,
+        settings,
+    )
+
+
+def test_transform_unnecessary_localtime_default_multiline():
+    check_transformed(
+        """\
+        timezone.localtime(
+            timezone.now()
+        )
+        timezone.localdate(
+        timezone.now())
+        """,
+        """\
+        timezone.localtime()
+        timezone.localdate()
+        """,
+        settings,
+    )
+
+
+def test_transform_conplicated_localtime():
+    check_transformed(
+        """\
+        timezone.make_aware(dt.datetime.now())
+        """,
+        """\
+        timezone.localtime()
+        """,
+        settings,
+    )


### PR DESCRIPTION
I've seen a lot of people quite confused with when to use `timezone.localtime` / `timezone.make_aware`  and `timezone.localdate` leading to a lot of weird pattern that could be achieved in more simple ways. This fixer simplify some of these cases.

```diff
-timezone.localtime(aware_date_or_datetime).date()
+timezone.localdate(aware_date_or_datetime)

-timezone.make_aware(dt.datetime.now())
+timezone.localtime()

-timezone.localtime(timezone.now())
+timezone.localtime()
-timezone.localdate(timezone.now())
+timezone.localdate()
```