### PR TITLE
Use `.fromisoformat` over `.strptime` when applicable (~100x faster)

### DIFF
--- a/src/django_upgrade/fixers/datetime_fromisoformat.py
+++ b/src/django_upgrade/fixers/datetime_fromisoformat.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import ast
+from functools import partial
+from typing import Iterable
+
+from tokenize_rt import Offset
+from tokenize_rt import Token
+
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.ast import is_name_attr
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+from django_upgrade.tokens import CODE
+from django_upgrade.tokens import NAME
+from django_upgrade.tokens import OP
+from django_upgrade.tokens import find
+from django_upgrade.tokens import find_and_replace_name
+from django_upgrade.tokens import parse_call_args
+from django_upgrade.tokens import remove_arg
+
+fixer = Fixer(
+    __name__,
+    min_version=(0, 0),
+)
+
+
+@fixer.register(ast.Call)
+def visit_Call(
+    state: State,
+    node: ast.Call,
+    parents: list[ast.AST],
+) -> Iterable[tuple[Offset, TokenFunc]]:
+    if (
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr == "strptime"
+        and len(node.args) == 2
+        and isinstance(node.args[1], ast.Constant)
+        and is_name_attr(
+            node=node.func.value,
+            imports=state.from_imports,
+            mods=("dt", "datetime"),
+            names={"datetime"},
+        )
+    ):
+        # dt.datetime.strptime("2024-02-12", "%Y-%m-%d").date()
+        if (
+            isinstance(parents[-1], ast.Attribute)
+            and parents[-1].attr == "date"
+            and node.args[1].value == "%Y-%m-%d"  # Isoformat
+            and isinstance(parents[-2], ast.Call)
+            and not parents[-2].args
+            and not parents[-2].keywords
+        ):
+            yield ast_start_offset(node), partial(use_isoformat_over_date_strptime)
+
+        # dt.datetime.strptime("2024-12-13T12:00:23", "%Y-%m-%dT%H:%M:%S")
+        elif node.args[1].value[:8] == "%Y-%m-%d" and node.args[1].value[9:] in {
+            "",
+            "%H",
+            "%H:%M",
+            "%H:%M:%S",
+            "%H:%M:%S.%f",
+        }:
+            yield ast_start_offset(node), partial(use_isoformat_over_datetime_strptime)
+
+
+def use_isoformat_over_date_strptime(tokens: list[Token], i: int) -> None:
+    open_idx = find(tokens, i, name=OP, src="(")
+    func_args, close_idx = parse_call_args(tokens, open_idx)
+
+    # Remove `.date()` attribute call.
+    attr_call_close_idx = find(tokens, close_idx, name=OP, src=")")
+    del tokens[close_idx : attr_call_close_idx + 1]
+
+    # Remove "%Y-%m-%d" 2nd argument
+    remove_arg(tokens, func_args, close_idx, arg_idx=1)
+
+    # Replace `datetime.strptime` with `date.fromisoformat`
+    datetime_idx = find(tokens, i, name=NAME, src="datetime")
+    tokens[datetime_idx:open_idx] = [Token(name=CODE, src="date.fromisoformat")]
+
+
+def use_isoformat_over_datetime_strptime(tokens: list[Token], i: int) -> None:
+    open_idx = find(tokens, i, name=OP, src="(")
+    func_args, close_idx = parse_call_args(tokens, open_idx)
+
+    # Remove 2nd argument (Format string)
+    remove_arg(tokens, func_args, close_idx, arg_idx=1)
+
+    # Replace `datetime.strptime` with `datetime.fromisoformat`
+    find_and_replace_name(tokens, i, name="strptime", new="fromisoformat")

--- a/tests/fixers/test_datetime_fromisoformat.py
+++ b/tests/fixers/test_datetime_fromisoformat.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from django_upgrade.data import Settings
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
+
+settings = Settings(target_version=(5, 0))
+
+DATE_FORMATS = (
+    "%Y-%m-%d",
+    "%Y-%m-%d %H",
+    "%Y-%m-%dT%H",
+    "%Y-%m-%dT%H:%M",
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y-%m-%dT%H:%M:%S.%f",
+)
+
+
+def test_noop_invalid_strptime_call():
+    check_noop(
+        """\
+        dt.datetime.strptime("2024-02-12", "%Y-%m-%d", "??").date()
+        """,
+        settings,
+    )
+
+
+def test_noop_custom_date_format():
+    check_noop(
+        """\
+        dt.datetime.strptime("2024-02-12", "%Y/%m/%d").date()
+        """,
+        settings,
+    )
+
+
+@pytest.mark.parametrize(
+    "date_format",
+    DATE_FORMATS,
+)
+def test_safe_round_trip_naive_datetime(date_format):
+    aware_datetime = dt.datetime(2024, 4, 14)
+    date_string = aware_datetime.strftime(date_format)
+
+    strptime_parsed_date = dt.datetime.strptime(date_string, date_format)
+    isoformat_parsed_date = dt.datetime.fromisoformat(date_string)
+    assert strptime_parsed_date == aware_datetime
+    assert isoformat_parsed_date == aware_datetime
+
+
+@pytest.mark.parametrize(
+    "date_format",
+    DATE_FORMATS,
+)
+def test_transform_datetime_single_line(date_format):
+    check_transformed(
+        f"""\
+        import datetime as dt
+        dt.datetime.strptime(date_string, {date_format!r})
+        """,
+        """\
+        import datetime as dt
+        dt.datetime.fromisoformat(date_string)
+        """,
+        settings,
+    )
+
+
+def test_transform_date_single_line():
+    check_transformed(
+        """\
+        import datetime as dt
+        dt.datetime.strptime("2024-02-12", "%Y-%m-%d").date()  # Date conversion
+        """,
+        """\
+        import datetime as dt
+        dt.date.fromisoformat("2024-02-12")  # Date conversion
+        """,
+        settings,
+    )
+
+
+def test_transform_mixed_line():
+    check_transformed(
+        """\
+        import datetime as dt
+        end_date=dt.datetime.strptime(
+            "2024-02-12", "%Y-%m-%d"
+        ).date()
+        """,
+        """\
+        import datetime as dt
+        end_date=dt.date.fromisoformat(
+            "2024-02-12"
+        )
+        """,
+        settings,
+    )
+
+
+def test_transform_multiline():
+    check_transformed(
+        """\
+        import datetime as dt
+        end_date=dt.datetime.strptime(
+            "2024-02-12",
+            "%Y-%m-%d",
+        ).date()
+        """,
+        """\
+        import datetime as dt
+        end_date=dt.date.fromisoformat(
+            "2024-02-12"
+        )
+        """,
+        settings,
+    )
+
+
+# @pytest.mark.skip(reason="TODO: improve remove_arg to keep comments")
+# def test_transform_mixed_line_with_comments():
+#     check_transformed(
+#         """\
+#         import datetime as dt
+#         dt.datetime.strptime( # comment 1
+#             # comment 2
+#             "2024-02-12", "%Y-%m-%d" # comment 3
+#             # comment 4
+#         ).date() # comment 5
+#         """,
+#         """\
+#         import datetime as dt
+#         dt.date.fromisoformat( # comment 1
+#             # comment 2
+#             "2024-02-12" # comment 3
+#             # comment 4
+#         ) # comment 5
+#         """,
+#         settings,
+#     )
+#
+#
+# @pytest.mark.skip(reason="TODO: improve remove_arg to keep comments")
+# def test_transform_multiline_with_comments():
+#     check_transformed(
+#         """\
+#         import datetime as dt
+#         dt.datetime.strptime( # comment 1
+#             # comment 2
+#             # comment 3
+#             "2024-02-12", # comment 4
+#             # comment 5
+#             "%Y-%m-%d" # comment 6
+#             # comment 7
+#         ).date() # comment 8
+#         """,
+#         """\
+#         import datetime as dt
+#         dt.datetime.strptime( # comment 1
+#             # comment 2
+#             # comment 3
+#             "2024-02-12", # comment 4
+#             # comment 5
+#             # comment 7
+#         ).date() # comment 8
+#         """,
+#         settings,
+#     )


### PR DESCRIPTION
```diff

- dt.datetime.strptime("2024-02-12", "%Y-%m-%d").date()
+ dt.date.fromisoformat("2024-02-12")

- dt.datetime.strptime("2024-12-13T12:00:23", "%Y-%m-%dT%H:%M:%S")
+ dt.datetime.fromisoformat("2024-12-13T12:00:23")
``` 
This is usually more succinct and readable and also happens to be a lot faster (~50-100x)

```python
>>> %timeit dt.datetime.strptime("2024-12-13T12:00:23", "%Y-%m-%dT%H:%M:%S")
4.06 µs ± 9.42 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

>>> %timeit dt.datetime.fromisoformat("2024-12-13T12:00:23")
66.5 ns ± 0.58 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```