### PR TITLE
Convert `strftime` in f-string to use date format specifier

### DIFF
--- a/src/django_upgrade/fixers/strftime_to_format_spec.py
+++ b/src/django_upgrade/fixers/strftime_to_format_spec.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import ast
+import re
+from functools import partial
+from typing import Iterable
+
+from tokenize_rt import Offset
+from tokenize_rt import Token
+
+from django_upgrade.ast import ast_start_offset
+from django_upgrade.data import Fixer
+from django_upgrade.data import State
+from django_upgrade.data import TokenFunc
+
+fixer = Fixer(
+    __name__,
+    min_version=(0, 0),
+)
+
+
+@fixer.register(ast.FormattedValue)
+def visit_FormattedValue(
+    state: State,
+    node: ast.FormattedValue,
+    parents: list[ast.AST],
+) -> Iterable[tuple[Offset, TokenFunc]]:
+    if (
+        isinstance(node.value, ast.Call)
+        and len(node.value.args) == 1
+        and isinstance(node.value.args[0], ast.Constant)
+        and isinstance(node.value.func, ast.Attribute)
+        and node.value.func.attr == "strftime"
+    ):
+        yield ast_start_offset(node), partial(fix_strftime_in_fstring)
+
+
+def fix_strftime_in_fstring(tokens: list[Token], i: int) -> None:
+    tokens[i] = tokens[i]._replace(
+        src=re.sub(r"\.strftime\(['\"](.*?)['\"]\)}", r":\1}", tokens[i].src)
+    )

--- a/tests/fixers/test_strftime_to_format_spec.py
+++ b/tests/fixers/test_strftime_to_format_spec.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from django_upgrade.data import Settings
+from tests.fixers.tools import check_noop
+from tests.fixers.tools import check_transformed
+
+settings = Settings(target_version=(5, 0))
+
+
+def test_noop_not_constant():
+    check_noop(
+        r"""
+        DATE_FORMAT = "%Y"
+        b = f"{dt.datetime.now().strftime(DATE_FORMAT)}"
+        """,
+        settings,
+    )
+
+
+def test_noop_empty_format():
+    check_noop(
+        r"""
+        DATE_FORMAT = "%Y"
+        b = f"{dt.datetime.now().strftime(DATE_FORMAT)}"
+        """,
+        settings,
+    )
+
+
+def test_noop_joined_str():
+    check_noop(
+        r"""
+        f' ''{dt.datetime.now().strftime("%Y")}'''
+        """,
+        settings,
+    )
+
+
+def test_noop_other_modifier():
+    check_noop(
+        r"""
+        f'''{dt.datetime.now().strftime("%Y")!r}'''
+        """,
+        settings,
+    )
+
+
+def test_noop_not_last_call():
+    check_noop(
+        r"""
+        f'''{dt.datetime.now().strftime("%Y").lower()}'''
+        """,
+        settings,
+    )
+
+
+def test_transform_single_quote():
+    check_transformed(
+        r"""
+        f'Now: {dt.datetime.now().strftime("%Y-%m-%d")}'
+        """,
+        r"""
+        f'Now: {dt.datetime.now():%Y-%m-%d}'
+        """,
+        settings,
+    )
+
+
+def test_transform_double_quote():
+    check_transformed(
+        r"""
+        f"Now: {dt.datetime.now().strftime('%Y-%m-%d')}"
+        """,
+        r"""
+        f"Now: {dt.datetime.now():%Y-%m-%d}"
+        """,
+        settings,
+    )
+
+
+def test_transform_single_quote_rf():
+    check_transformed(
+        r"""
+        rf'Now: {dt.datetime.now().strftime("%Y-%m-%d")}'
+        """,
+        r"""
+        rf'Now: {dt.datetime.now():%Y-%m-%d}'
+        """,
+        settings,
+    )
+
+
+def test_transform_double_quote_rf():
+    check_transformed(
+        r"""
+        fr"Now: {dt.datetime.now().strftime('%Y-%m-%d')}"
+        """,
+        r"""
+        fr"Now: {dt.datetime.now():%Y-%m-%d}"
+        """,
+        settings,
+    )
+
+
+def test_transform_triple_quoted_string():
+    check_transformed(
+        r"""
+        f'''{dt.datetime.now().strftime("%Y")}'''
+        f'''       {dt.datetime.now().strftime("%Y")}     '''
+        f'''{dt.datetime.now().strftime("%Y")}     '''
+        """,
+        r"""
+        f'''{dt.datetime.now():%Y}'''
+        f'''       {dt.datetime.now():%Y}     '''
+        f'''{dt.datetime.now():%Y}     '''
+        """,
+        settings,
+    )
+
+
+def test_transform_multiple_pattern():
+    check_transformed(
+        r"""
+        now = dt.datetime.now()
+        f"Now: {now.strftime('%Y-%m-%d')}, Now 2: {now.strftime('%Y-%m-%d')}"
+        """,
+        r"""
+        now = dt.datetime.now()
+        f"Now: {now:%Y-%m-%d}, Now 2: {now:%Y-%m-%d}"
+        """,
+        settings,
+    )
+
+
+def test_transform_weird_pattern_with_spaces():
+    check_transformed(
+        r"""
+        f"Now: {dt.datetime.now().strftime('%d/%m/%Y after %H:%M')}"
+        """,
+        r"""
+        f"Now: {dt.datetime.now():%d/%m/%Y after %H:%M}"
+        """,
+        settings,
+    )


### PR DESCRIPTION
 ```diff
- f"Now: {dt.datetime.now().strftime('%Y-%m-%d')}"
+ f"Now: {dt.datetime.now():%Y-%m-%d}"
```

This also support single quotes, raw string and triple-quoted strings.
Also work with python3.12 new f-string parsing